### PR TITLE
Fix GitHub URL typo propagated to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=readme,
     author='Piper Merriam',
     author_email='pipermerriam@gmail.com',
-    url='https://github.com/pipermerriam/trie',
+    url='https://github.com/pipermerriam/py-trie',
     include_package_data=True,
     py_modules=['trie'],
     install_requires=[


### PR DESCRIPTION
### What was wrong?
While exploring py-evm codebase, ran into a 404 while following link to trie codebase in PyPI


### How was it fixed?
GitHub search, copy, paste.


#### Cute Animal Picture

![](https://i.imgur.com/QvQHqWZ.jpg)
