### PR TITLE
amend: remove __future__.absolute_import in __init__.py

### DIFF
--- a/trie/__init__.py
+++ b/trie/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pkg_resources
 import sys
 import warnings


### PR DESCRIPTION
### What was wrong?
 `__future__.absolute_import` in `__init__.py` was left out in last commit

### How was it fixed?
removed


#### Cute Animal Picture

![Cute animal picture](http://i.dailymail.co.uk/i/pix/2011/09/22/article-0-0E08569A00000578-641_634x475.jpg)
