### PR TITLE
 add trie.delete_subtrie and if_branch_exist utility function

### DIFF
--- a/tests/test_bin_trie.py
+++ b/tests/test_bin_trie.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hypothesis import (
     given,
     strategies as st,
@@ -9,6 +11,9 @@ from trie.trie import (
 )
 from trie.constants import (
     BLANK_HASH,
+)
+from trie.exceptions import (
+    LeafNodeOverrideError,
 )
 
 
@@ -36,3 +41,44 @@ def test_bin_trie_different_order_insert(k, v, random):
         for k, v in kv_pairs:
             trie.delete(k)
         assert trie.root_hash == BLANK_HASH
+
+
+def test_bin_trie_delete_subtrie():
+    trie = BinaryTrie(db={})
+    # First test case, delete subtrie of a kv node
+    trie.set(b'\x12\x34\x56\x78', b'78')
+    trie.set(b'\x12\x34\x56\x79', b'79')
+    assert trie.get(b'\x12\x34\x56\x78') == b'78'
+    assert trie.get(b'\x12\x34\x56\x79') == b'79'
+
+    trie.delete_subtrie(b'\x12\x34\x56')
+    assert trie.get(b'\x12\x34\x56\x78') == None
+    assert trie.get(b'\x12\x34\x56\x79') == None
+    assert trie.root_hash == BLANK_HASH
+
+    # Second test case, delete subtrie of a branch node
+    trie.set(b'\x12\x34\x56\x78', b'78')
+    trie.set(b'\x12\x34\x56\xff', b'ff')
+    assert trie.get(b'\x12\x34\x56\x78') == b'78'
+    assert trie.get(b'\x12\x34\x56\xff') == b'ff'
+
+    trie.delete_subtrie(b'\x12\x34\x56')
+    assert trie.get(b'\x12\x34\x56\x78') == None
+    assert trie.get(b'\x12\x34\x56\xff') == None
+    assert trie.root_hash == BLANK_HASH
+
+    # Third test case, delete subtrie with non-exist key
+    trie.set(b'\x12\x34\x56\x78', b'78')
+    trie.set(b'\x12\x34\x56\x79', b'79')
+    assert trie.get(b'\x12\x34\x56\x78') == b'78'
+    assert trie.get(b'\x12\x34\x56\x79') == b'79'
+    root_hash_before_delete = trie.root_hash
+
+    trie.delete_subtrie(b'\x12\x34\x57')
+    assert trie.get(b'\x12\x34\x56\x78') == b'78'
+    assert trie.get(b'\x12\x34\x56\x79') == b'79'
+    assert trie.root_hash == root_hash_before_delete
+
+    # Fourth test case, delete subtrie with key too long
+    with pytest.raises(LeafNodeOverrideError):
+        trie.delete_subtrie(b'\x12\x34\x56\x78\x9a')

--- a/tests/test_bin_trie.py
+++ b/tests/test_bin_trie.py
@@ -43,42 +43,35 @@ def test_bin_trie_different_order_insert(k, v, random):
         assert trie.root_hash == BLANK_HASH
 
 
-def test_bin_trie_delete_subtrie():
+@pytest.mark.parametrize(
+    'kv1,kv2,key_to_be_deleted,will_delete,will_rasie_error',
+    (
+        ((b'\x12\x34\x56\x78', b'78'), (b'\x12\x34\x56\x79', b'79'), b'\x12\x34\x56', True, False),
+        ((b'\x12\x34\x56\x78', b'78'), (b'\x12\x34\x56\xff', b'ff'), b'\x12\x34\x56', True, False),
+        ((b'\x12\x34\x56\x78', b'78'), (b'\x12\x34\x56\x79', b'79'), b'\x12\x34\x57', False, False),
+        ((b'\x12\x34\x56\x78', b'78'), (b'\x12\x34\x56\x79', b'79'), b'\x12\x34\x56\x78\x9a', False, True),
+    ),
+)
+def test_bin_trie_delete_subtrie(kv1, kv2, key_to_be_deleted, will_delete, will_rasie_error):
     trie = BinaryTrie(db={})
     # First test case, delete subtrie of a kv node
-    trie.set(b'\x12\x34\x56\x78', b'78')
-    trie.set(b'\x12\x34\x56\x79', b'79')
-    assert trie.get(b'\x12\x34\x56\x78') == b'78'
-    assert trie.get(b'\x12\x34\x56\x79') == b'79'
+    trie.set(kv1[0], kv1[1])
+    trie.set(kv2[0], kv2[1])
+    assert trie.get(kv1[0]) == kv1[1]
+    assert trie.get(kv2[0]) == kv2[1]
 
-    trie.delete_subtrie(b'\x12\x34\x56')
-    assert trie.get(b'\x12\x34\x56\x78') == None
-    assert trie.get(b'\x12\x34\x56\x79') == None
-    assert trie.root_hash == BLANK_HASH
-
-    # Second test case, delete subtrie of a branch node
-    trie.set(b'\x12\x34\x56\x78', b'78')
-    trie.set(b'\x12\x34\x56\xff', b'ff')
-    assert trie.get(b'\x12\x34\x56\x78') == b'78'
-    assert trie.get(b'\x12\x34\x56\xff') == b'ff'
-
-    trie.delete_subtrie(b'\x12\x34\x56')
-    assert trie.get(b'\x12\x34\x56\x78') == None
-    assert trie.get(b'\x12\x34\x56\xff') == None
-    assert trie.root_hash == BLANK_HASH
-
-    # Third test case, delete subtrie with non-exist key
-    trie.set(b'\x12\x34\x56\x78', b'78')
-    trie.set(b'\x12\x34\x56\x79', b'79')
-    assert trie.get(b'\x12\x34\x56\x78') == b'78'
-    assert trie.get(b'\x12\x34\x56\x79') == b'79'
-    root_hash_before_delete = trie.root_hash
-
-    trie.delete_subtrie(b'\x12\x34\x57')
-    assert trie.get(b'\x12\x34\x56\x78') == b'78'
-    assert trie.get(b'\x12\x34\x56\x79') == b'79'
-    assert trie.root_hash == root_hash_before_delete
-
-    # Fourth test case, delete subtrie with key too long
-    with pytest.raises(LeafNodeOverrideError):
-        trie.delete_subtrie(b'\x12\x34\x56\x78\x9a')
+    if will_delete:
+        trie.delete_subtrie(key_to_be_deleted)
+        assert trie.get(kv1[0]) == None
+        assert trie.get(kv2[0]) == None
+        assert trie.root_hash == BLANK_HASH
+    else:
+        if will_rasie_error:
+            with pytest.raises(LeafNodeOverrideError):
+                trie.delete_subtrie(key_to_be_deleted)
+        else:
+            root_hash_before_delete = trie.root_hash
+            trie.delete_subtrie(key_to_be_deleted)
+            assert trie.get(kv1[0]) == kv1[1]
+            assert trie.get(kv2[0]) == kv2[1]
+            assert trie.root_hash == root_hash_before_delete

--- a/tests/test_branches_utils.py
+++ b/tests/test_branches_utils.py
@@ -1,0 +1,33 @@
+import pytest
+
+from trie.trie import (
+    BinaryTrie,
+)
+from trie.utils.branches import (
+    if_branch_exist,
+)
+
+
+def set_up_test_trie():
+    trie = BinaryTrie(db={})
+    trie.set(b'\x12\x34\x56\x78\x9a', b'9a')
+    trie.set(b'\x12\x34\x56\x78\x9b', b'9b')
+    trie.set(b'\x12\x34\x56\xff', b'ff')
+
+    return trie
+
+
+@pytest.mark.parametrize(
+    'key_prefix,if_exist',
+    (
+        (b'\x12\x34', True),
+        (b'\x12\x34\x56\x78\x9b', True),
+        (b'\x12\x56', False),
+        (b'\x12\x34\x56\xff\xff', False),
+        (b'\x12\x34\x56', True),
+        (b'\x12\x34\x56\x78', True),
+    ),
+)
+def test_branch_exist(key_prefix, if_exist):
+    test_trie = set_up_test_trie()
+    assert if_branch_exist(test_trie.db, test_trie.root_hash, key_prefix) == if_exist

--- a/tests/test_branches_utils.py
+++ b/tests/test_branches_utils.py
@@ -7,8 +7,8 @@ from trie.utils.branches import (
     if_branch_exist,
 )
 
-
-def set_up_test_trie():
+@pytest.fixture
+def test_trie():
     trie = BinaryTrie(db={})
     trie.set(b'\x12\x34\x56\x78\x9a', b'9a')
     trie.set(b'\x12\x34\x56\x78\x9b', b'9b')
@@ -28,6 +28,5 @@ def set_up_test_trie():
         (b'\x12\x34\x56\x78', True),
     ),
 )
-def test_branch_exist(key_prefix, if_exist):
-    test_trie = set_up_test_trie()
+def test_branch_exist(test_trie, key_prefix, if_exist):
     assert if_branch_exist(test_trie.db, test_trie.root_hash, key_prefix) == if_exist

--- a/trie/trie.py
+++ b/trie/trie.py
@@ -600,12 +600,16 @@ class BinaryTrie(object):
             return self._hash_and_save(encode_branch_node(new_left_child, new_right_child))
 
     def exists(self, key):
+        validate_is_bytes(key)
+
         return self.get(key) != BLANK_NODE
 
     def delete(self, key):
         """
         Equals to setting the value to None
         """
+        validate_is_bytes(key)
+
         self.root_hash = self._set(self.root_hash, encode_to_bin(key), b'')
 
     #
@@ -618,6 +622,7 @@ class BinaryTrie(object):
     @root_node.setter
     def root_node(self, node):
         validate_is_bin_node(node)
+        
         self.root_hash = self._hash_and_save(node)
 
     #

--- a/trie/utils/branches.py
+++ b/trie/utils/branches.py
@@ -1,0 +1,46 @@
+from trie.constants import (
+    BLANK_HASH,
+    KV_TYPE,
+    BRANCH_TYPE,
+    LEAF_TYPE,
+    BYTE_0,
+)
+from trie.utils.binaries import (
+    encode_to_bin,
+)
+from trie.utils.nodes import (
+    parse_node,
+)
+
+
+def if_branch_exist(db, node_hash, key_prefix):
+    return _if_branch_exist(db, node_hash, encode_to_bin(key_prefix))
+
+
+def _if_branch_exist(db, node_hash, key_prefix):
+    # Empty trie
+    if node_hash == BLANK_HASH:
+        return False
+    nodetype, left_child, right_child = parse_node(db[node_hash])
+    if nodetype == LEAF_TYPE:
+        if key_prefix:
+            return False
+        return True
+    elif nodetype == KV_TYPE:
+        if not key_prefix:
+            return True
+        if len(key_prefix) < len(left_child):
+            if key_prefix == left_child[:len(key_prefix)]:
+                return True
+            return False
+        else:
+            if key_prefix[:len(left_child)] == left_child:
+                return _if_branch_exist(db, right_child, key_prefix[len(left_child):])
+            return False
+    elif nodetype == BRANCH_TYPE:
+        if not key_prefix:
+            return True
+        if key_prefix[:1] == BYTE_0:
+            return _if_branch_exist(db, left_child, key_prefix[1:])
+        else:
+            return _if_branch_exist(db, right_child, key_prefix[1:])


### PR DESCRIPTION
### How was it fixed?
Add `trie.delete_subtrie`, which is needed in py-evm Account Redesign, and some tests.
Renamed `delete_branch` to `delete_subtrie` for that `delete_subtrie` is closer to it's actual effect.

Will update `if_branch_exist` and tests soon. `if_branch_exist` will be placed in `trie/utils/branches.py` which is where utility functions for trie branch are stored.
There will be more branch utils and their tests added in next PR. 


#### Cute Animal Picture

![Cute animal picture](https://static.boredpanda.com/blog/wp-content/uploads/2016/02/cute-baby-polar-bear-day-photography-35__880.jpg)
