### PR TITLE
fix missing super call

### DIFF
--- a/tests/test_deprecated_trie_class.py
+++ b/tests/test_deprecated_trie_class.py
@@ -1,0 +1,12 @@
+import pytest
+
+from trie import Trie
+
+
+def test_deprecated_trie():
+    with pytest.warns(DeprecationWarning):
+        trie = Trie(db={})
+
+    trie[b'foo'] = b'bar'
+    assert b'foo' in trie
+    assert trie[b'foo'] == b'bar'

--- a/trie/__init__.py
+++ b/trie/__init__.py
@@ -18,6 +18,7 @@ class Trie(HexaryTrie):
             "a subsequent release"
         ))
         warnings.resetwarnings()
+        super().__init__(*args, **kwargs)
 
 
 __version__ = pkg_resources.get_distribution("trie").version


### PR DESCRIPTION
### What was wrong?

The deprecated `Trie` class was missing a `super` call in it's constructor

### How was it fixed?

Added it.

#### Cute Animal Picture

![4321604551_655f2c2b10_b](https://user-images.githubusercontent.com/824194/34573381-43ed0ee6-f131-11e7-927b-41de2229f6b8.jpg)

  