### PR TITLE
some Binary Trie updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ False
 >>>     check_if_branch_exist,
 >>>     get_branch,
 >>>     if_branch_valid,
->>>     get_witness,
+>>>     get_witness_for_key_prefix,
 >>> )
 >>> t = BinaryTrie(db={})
 >>> t.root_hash
@@ -186,10 +186,10 @@ True
 >>> b = get_branch(t.db, t.root_hash, b'key2')
 >>> if_branch_valid(b, t.root_hash, b'key1', v) # KeyError
 >>> if_branch_valid([], t.root_hash, b'key1', v) # AssertionError
->>> # get_witness function
->>> get_witness(t.db, t.root_hash, b'key1') # equivalent to `get_branch(t.db, t.root_hash, b'key1')`
+>>> # get_witness_for_key_prefix function
+>>> get_witness_for_key_prefix(t.db, t.root_hash, b'key1') # equivalent to `get_branch(t.db, t.root_hash, b'key1')`
 (b'\x00\x82\x1a\xd9^L|38J\xed\xf31S\xb2\x97A\x8dy\x91RJ\x92\xf5ZC\xb4\x99T&;!\x9f\xa9!\xa2\xfe;', b"\x01*\xaccxH\x89\x08}\x93|\xda\xb9\r\x9b\x82\x8b\xb2Y\xbc\x10\xb9\x88\xf40\xef\xed\x8b'\x13\xbc\xa5\xccYGb\xc2\x8db\x88lPs@)\x86v\xd7B\xf7\xd3X\x93\xc9\xf0\xfd\xae\xe0`j#\x0b\xca;\xf8", b'\x00\x11\x8aEL3\x839E\xbd\xc4G\xd1xj\x0fxWu\xcb\xf6\xf3\xf2\x8e7!M\xca\x1c/\xd7\x7f\xed\xc6', b'\x02value1')
->>> get_witness(t.db, t.root_hash, b'key') # this will include additional nodes of b'key2'
+>>> get_witness_for_key_prefix(t.db, t.root_hash, b'key') # this will include additional nodes of b'key2'
 (b'\x00\x82\x1a\xd9^L|38J\xed\xf31S\xb2\x97A\x8dy\x91RJ\x92\xf5ZC\xb4\x99T&;!\x9f\xa9!\xa2\xfe;', b"\x01*\xaccxH\x89\x08}\x93|\xda\xb9\r\x9b\x82\x8b\xb2Y\xbc\x10\xb9\x88\xf40\xef\xed\x8b'\x13\xbc\xa5\xccYGb\xc2\x8db\x88lPs@)\x86v\xd7B\xf7\xd3X\x93\xc9\xf0\xfd\xae\xe0`j#\x0b\xca;\xf8", b'\x00\x11\x8aEL3\x839E\xbd\xc4G\xd1xj\x0fxWu\xcb\xf6\xf3\xf2\x8e7!M\xca\x1c/\xd7\x7f\xed\xc6', b'\x02value1', b'\x00\x10O\xa9\x0b\x1c!_`<\xb5^\x98D\x89\x17\x148\xac\xda&\xb3P\xf6\x06[\x1b9\xc09\xbas\x85\xf5', b'\x02value2')
->>> get_witness(t.db, t.root_hash, b'') # this will return the whole trie
+>>> get_witness_for_key_prefix(t.db, t.root_hash, b'') # this will return the whole trie
 ```

--- a/tests/test_bin_trie.py
+++ b/tests/test_bin_trie.py
@@ -75,3 +75,28 @@ def test_bin_trie_delete_subtrie(kv1, kv2, key_to_be_deleted, will_delete, will_
             assert trie.get(kv1[0]) == kv1[1]
             assert trie.get(kv2[0]) == kv2[1]
             assert trie.root_hash == root_hash_before_delete
+
+
+@pytest.mark.parametrize(
+    'invalide_key,if_error',
+    (
+        (b'\x12\x34\x56', False),
+        (b'\x12\x34\x56\x77', False),
+        (b'\x12\x34\x56\x78\x9a', True),
+        (b'\x12\x34\x56\x79\xab', True),
+        (b'\xab\xcd\xef', False),
+    ),
+)
+def test_bin_trie_invalid_key(invalide_key, if_error):
+    trie = BinaryTrie(db={})
+    trie.set(b'\x12\x34\x56\x78', b'78')
+    trie.set(b'\x12\x34\x56\x79', b'79')
+    
+    assert trie.get(invalide_key) == None
+    if if_error:
+        with pytest.raises(LeafNodeOverrideError):
+            trie.delete(invalide_key)
+    else:
+        previous_root_hash = trie.root_hash
+        trie.delete(invalide_key)
+        assert previous_root_hash == trie.root_hash

--- a/tests/test_branches_utils.py
+++ b/tests/test_branches_utils.py
@@ -12,7 +12,7 @@ from trie.branches import (
     get_branch,
     if_branch_valid,
     get_trie_nodes,
-    get_witness,
+    get_witness_for_key_prefix,
 )
 
 @pytest.fixture
@@ -159,9 +159,9 @@ def test_get_trie_nodes(test_trie, root, nodes):
         ),
     ),
 )
-def test_get_witness(test_trie, key, nodes):
+def test_get_witness_for_key_prefix(test_trie, key, nodes):
     if nodes:
-        assert set(nodes) == set(get_witness(test_trie.db, test_trie.root_hash, key))
+        assert set(nodes) == set(get_witness_for_key_prefix(test_trie.db, test_trie.root_hash, key))
     else:
         with pytest.raises(InvalidKeyError):
-            get_witness(test_trie.db, test_trie.root_hash, key)
+            get_witness_for_key_prefix(test_trie.db, test_trie.root_hash, key)

--- a/trie/binary.py
+++ b/trie/binary.py
@@ -64,6 +64,8 @@ class BinaryTrie(object):
         nodetype, left_child, right_child = parse_node(self.db[node_hash])
         # Key-value node descend
         if nodetype == LEAF_TYPE:
+            if keypath:
+                return None
             return right_child
         elif nodetype == KV_TYPE:
             # Keypath too short

--- a/trie/branches.py
+++ b/trie/branches.py
@@ -152,7 +152,7 @@ def _get_trie_nodes(db, node_hash):
         raise Exception("Invariant: unreachable code path")
 
 
-def get_witness(db, node_hash, key):
+def get_witness_for_key_prefix(db, node_hash, key):
     """
     Get all witness given a keypath prefix.
     Include
@@ -162,10 +162,10 @@ def get_witness(db, node_hash, key):
     """
     validate_is_bytes(key)
 
-    return tuple(_get_witness(db, node_hash, encode_to_bin(key)))
+    return tuple(_get_witness_for_key_prefix(db, node_hash, encode_to_bin(key)))
 
 
-def _get_witness(db, node_hash, keypath):
+def _get_witness_for_key_prefix(db, node_hash, keypath):
     if not keypath:
         yield from get_trie_nodes(db, node_hash)
     if node_hash in db:
@@ -182,15 +182,15 @@ def _get_witness(db, node_hash, keypath):
             yield from get_trie_nodes(db, right_child)
         elif keypath[:len(left_child)] == left_child:
             yield node
-            yield from _get_witness(db, right_child, keypath[len(left_child):])
+            yield from _get_witness_for_key_prefix(db, right_child, keypath[len(left_child):])
         else:
             yield node
     elif nodetype == BRANCH_TYPE:
         if keypath[:1] == BYTE_0:
             yield node
-            yield from _get_witness(db, left_child, keypath[1:])
+            yield from _get_witness_for_key_prefix(db, left_child, keypath[1:])
         else:
             yield node
-            yield from _get_witness(db, right_child, keypath[1:])
+            yield from _get_witness_for_key_prefix(db, right_child, keypath[1:])
     else:
         raise Exception("Invariant: unreachable code path")


### PR DESCRIPTION
### How was it fixed?
- [x] rename "get_witness" to "get_witness_for_key_prefix"
- [x] fix: have `get()` return None for key which is too long even if it's prefix is a valid key, e.g.,
if `trie.get(b'\x00\x11\x22')` returns `b'123'`, `trie.get(b'\x00\x11\x22\x33')` should return `None`
- [x] add invalid key `get`/`delete` test

#### Cute Animal Picture

![](https://static.boredpanda.com/blog/wp-content/uploads/2016/10/cute-sloths-57f269182f5ab__700.jpg)