### PR TITLE
Bintrie update on key-being-prefix-of-another-key problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ True
 False
 ```
 
+## BinaryTrie
+- Note: One drawback of Binary Trie is that **one key can not be the prefix of another key**. For example,
+if you already set the value `value1` with key `key1`, you can not set another value with key `key` or `key11`
+and the like.
+
 ### BinaryTrie branch and witness helper functions
 
 ```python

--- a/tests/test_bin_trie.py
+++ b/tests/test_bin_trie.py
@@ -13,7 +13,7 @@ from trie.constants import (
     BLANK_HASH,
 )
 from trie.exceptions import (
-    LeafNodeOverrideError,
+    NodeOverrideError,
 )
 
 
@@ -67,7 +67,7 @@ def test_bin_trie_delete_subtrie(kv1, kv2, key_to_be_deleted, will_delete, will_
         assert trie.root_hash == BLANK_HASH
     else:
         if will_rasie_error:
-            with pytest.raises(LeafNodeOverrideError):
+            with pytest.raises(NodeOverrideError):
                 trie.delete_subtrie(key_to_be_deleted)
         else:
             root_hash_before_delete = trie.root_hash
@@ -94,7 +94,7 @@ def test_bin_trie_invalid_key(invalide_key, if_error):
 
     assert trie.get(invalide_key) is None
     if if_error:
-        with pytest.raises(LeafNodeOverrideError):
+        with pytest.raises(NodeOverrideError):
             trie.delete(invalide_key)
     else:
         previous_root_hash = trie.root_hash

--- a/trie/binary.py
+++ b/trie/binary.py
@@ -117,8 +117,8 @@ class BinaryTrie(object):
             # Keypath must match, there should be no remaining keypath
             if keypath:
                 raise NodeOverrideError(
-                    "Existing kv pair is being effaced because"
-                    " it's key is the prefix of the new key")
+                    "Fail to set the value because the prefix of it's key"
+                    " is the same as existing key")
             if if_delete_subtrie:
                 return BLANK_HASH
             return self._hash_and_save(encode_leaf_node(value)) if value else BLANK_HASH
@@ -211,6 +211,10 @@ class BinaryTrie(object):
             # Case 2: keypath prefixes mismatch in the middle, so we need to break
             # the keypath in half. We are in case (3), (4), (7), (8)
             else:
+                if len(keypath[common_prefix_len + 1:]) == 0:
+                    raise NodeOverrideError(
+                        "Fail to set the value because it's key"
+                        " is the prefix of other existing key")
                 valnode = self._hash_and_save(
                     encode_kv_node(
                         keypath[common_prefix_len + 1:],
@@ -256,6 +260,10 @@ class BinaryTrie(object):
             if_delete_subtrie=False):
         # Which child node to update? Depends on first bit in keypath
         if keypath[:1] == BYTE_0:
+            if len(keypath[1:]) == 0:
+                raise NodeOverrideError(
+                    "Fail to set the value because it's key"
+                    " is the prefix of other existing key")
             new_left_child = self._set(left_child, keypath[1:], value, if_delete_subtrie)
             new_right_child = right_child
         else:

--- a/trie/binary.py
+++ b/trie/binary.py
@@ -15,7 +15,7 @@ from trie.validation import (
     validate_is_bin_node,
 )
 from trie.exceptions import (
-    LeafNodeOverrideError,
+    NodeOverrideError,
 )
 
 from trie.utils.sha3 import (
@@ -116,7 +116,7 @@ class BinaryTrie(object):
         if nodetype == LEAF_TYPE:
             # Keypath must match, there should be no remaining keypath
             if keypath:
-                raise LeafNodeOverrideError(
+                raise NodeOverrideError(
                     "Existing kv pair is being effaced because"
                     " it's key is the prefix of the new key")
             if if_delete_subtrie:

--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -14,7 +14,7 @@ class BadTrieProof(Exception):
     pass
 
 
-class LeafNodeOverrideError(Exception):
+class NodeOverrideError(Exception):
     pass
 
 


### PR DESCRIPTION
### What was wrong?
Currently the explanation for key-being-prefix-of-another-key problem is not good enough. The only explanations while this is triggered are "Key path can not be empty" and "Existing kv pair is being effaced because it's key is the prefix of the new key" which are not so clear really.


### How was it fixed?
- [x] Add check to catch this exact error and provide explanation for the problem.
- [x] Add warning to `README.md`


#### Cute Animal Picture

![](https://static.boredpanda.com/blog/wp-content/uploads/2017/05/cute-baby-hippos-6-590841d1ae669__700.jpg)