### PR TITLE
Fix: BinaryTrie.exist and node override error check

### DIFF
--- a/tests/test_bin_trie.py
+++ b/tests/test_bin_trie.py
@@ -103,12 +103,26 @@ def test_bin_trie_invalid_key(invalide_key, if_error):
 
 
 @given(keys=st.lists(st.binary(min_size=32, max_size=32), min_size=100, max_size=100, unique=True),
-       chosen_numbers=st.lists(st.integers(min_value=0, max_value=99), min_size=50, max_size=50))
+       chosen_numbers=st.lists(
+           st.integers(min_value=0, max_value=99),
+           min_size=50,
+           max_size=50,
+           unique=True)
+       )
 @settings(max_examples=10)
 def test_bin_trie_update_value(keys, chosen_numbers):
+    """
+    This is a basic test to see if updating value works as expected.
+    """
     trie = BinaryTrie(db={})
     for key in keys:
         trie.set(key, b'old')
-    
+
+    current_root = trie.root_hash
     for i in chosen_numbers:
+        trie.set(keys[i], b'old')
+        assert current_root == trie.root_hash
         trie.set(keys[i], b'new')
+        assert current_root != trie.root_hash
+        assert trie.get(keys[i]) == b'new'
+        current_root = trie.root_hash

--- a/tests/test_bin_trie.py
+++ b/tests/test_bin_trie.py
@@ -100,3 +100,15 @@ def test_bin_trie_invalid_key(invalide_key, if_error):
         previous_root_hash = trie.root_hash
         trie.delete(invalide_key)
         assert previous_root_hash == trie.root_hash
+
+
+@given(keys=st.lists(st.binary(min_size=32, max_size=32), min_size=100, max_size=100, unique=True),
+       chosen_numbers=st.lists(st.integers(min_value=0, max_value=99), min_size=50, max_size=50))
+@settings(max_examples=10)
+def test_bin_trie_update_value(keys, chosen_numbers):
+    trie = BinaryTrie(db={})
+    for key in keys:
+        trie.set(key, b'old')
+    
+    for i in chosen_numbers:
+        trie.set(keys[i], b'new')

--- a/trie/binary.py
+++ b/trie/binary.py
@@ -1,8 +1,6 @@
 import rlp
 
 from trie.constants import (
-    BLANK_NODE,
-    BLANK_NODE_HASH,
     BLANK_HASH,
     KV_TYPE,
     BRANCH_TYPE,
@@ -34,7 +32,6 @@ from trie.utils.nodes import (
 
 
 # sanity check
-assert BLANK_NODE_HASH == keccak(rlp.encode(b''))
 assert BLANK_HASH == keccak(b'')
 
 
@@ -299,7 +296,7 @@ class BinaryTrie(object):
     def exists(self, key):
         validate_is_bytes(key)
 
-        return self.get(key) != BLANK_NODE
+        return self.get(key) is not None
 
     def delete(self, key):
         """

--- a/trie/binary.py
+++ b/trie/binary.py
@@ -1,5 +1,3 @@
-import rlp
-
 from trie.constants import (
     BLANK_HASH,
     KV_TYPE,

--- a/trie/binary.py
+++ b/trie/binary.py
@@ -123,7 +123,10 @@ class BinaryTrie(object):
             if not keypath:
                 if if_delete_subtrie:
                     return BLANK_HASH
-                return node_hash
+                else:
+                    raise NodeOverrideError(
+                        "Fail to set the value because it's key"
+                        " is the prefix of other existing key")
             return self._set_kv_node(
                 keypath,
                 node_hash,
@@ -139,7 +142,10 @@ class BinaryTrie(object):
             if not keypath:
                 if if_delete_subtrie:
                     return BLANK_HASH
-                return node_hash
+                else:
+                    raise NodeOverrideError(
+                        "Fail to set the value because it's key"
+                        " is the prefix of other existing key")
             return self._set_branch_node(
                 keypath,
                 nodetype,
@@ -206,7 +212,7 @@ class BinaryTrie(object):
             # Case 2: keypath prefixes mismatch in the middle, so we need to break
             # the keypath in half. We are in case (3), (4), (7), (8)
             else:
-                if len(keypath[common_prefix_len + 1:]) == 0:
+                if len(keypath) <= common_prefix_len:
                     raise NodeOverrideError(
                         "Fail to set the value because it's key"
                         " is the prefix of other existing key")
@@ -255,10 +261,6 @@ class BinaryTrie(object):
             if_delete_subtrie=False):
         # Which child node to update? Depends on first bit in keypath
         if keypath[:1] == BYTE_0:
-            if len(keypath[1:]) == 0:
-                raise NodeOverrideError(
-                    "Fail to set the value because it's key"
-                    " is the prefix of other existing key")
             new_left_child = self._set(left_child, keypath[1:], value, if_delete_subtrie)
             new_right_child = right_child
         else:


### PR DESCRIPTION
### What was wrong?
Part 1. As pointed out in #32, `b'hello' not in binary_trie` should return `True` .
Part 2. Update in #31 misplace the node override check in `_set_branch_node` and causing some value updates to fail as pointed out in #34 .

### How was it fixed?
Part 1. `BinaryTrie.exist()` should check the returned value against `None` instead of `BLANK_NODE`.
Also remove `BLANK_NODE` and `BLANK_NODE_HASH` which are only related to `HexaryTrie`.
Part 2. Move the node override check to `_set`.

#### Cute Animal Picture

![Cute animal picture](http://www.publicdomainpictures.net/pictures/40000/velka/cute-spaniel-puppy-dog.jpg)