### PR TITLE
Fixed rlp package version requirement and latest eth-utils compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     py_modules=['trie'],
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-utils>=1.0.0b2,<2.0.0",
+        "eth-utils>=1.0.0,<2.0.0",
         "rlp>=0.4.7,<1.0.0",
     ],
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     install_requires=[
         "eth-utils>=1.0.0b2,<2.0.0",
-        "rlp==0.4.7,<1.0.0",
+        "rlp>=0.4.7,<1.0.0",
     ],
     license="MIT",
     zip_safe=False,

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -8,7 +8,8 @@ import os
 from eth_utils import (
     is_0x_prefixed,
     decode_hex,
-    force_bytes,
+    text_if_str,
+    to_bytes,
 )
 
 from trie import HexaryTrie
@@ -18,9 +19,9 @@ def normalize_fixture(fixture):
     normalized_fixture = {
         'in': tuple(
             (
-                decode_hex(key) if is_0x_prefixed(key) else force_bytes(key),
+                decode_hex(key) if is_0x_prefixed(key) else text_if_str(to_bytes, key),
                 (
-                    decode_hex(value) if is_0x_prefixed(value) else force_bytes(value)
+                    decode_hex(value) if is_0x_prefixed(value) else text_if_str(to_bytes, value)
                 ) if value is not None else None,
             )
             for key, value


### PR DESCRIPTION
### What was wrong?

1. `"rlp==0.4.7,<1.0.0"` should be `"rlp>=0.4.7,<1.0.0"`.
2. Some eth-utils APIs are deprecated.

### How was it fixed?
1. `"rlp==0.4.7,<1.0.0"` ->`"rlp>=0.4.7,<1.0.0"`.
2. Replaced `force_bytes` with `to_bytes`.

#### Cute Animal Picture

![pexels-photo-134392](https://user-images.githubusercontent.com/9263930/37048338-8e79e982-21a8-11e8-8168-7309cba67567.jpeg)
