### PR TITLE
A couple misc fixes to HexaryTrieSync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     - python: "3.5"
       env: TOX_POSARGS="-e flake8"
     # core
-    - python: "3.4"
-      env: TOX_POSARGS="-e py34"
     - python: "3.5"
       env: TOX_POSARGS="-e py35"
     - python: "3.6"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{34,35,36}
+    py{35,36}
     flake8
 
 [flake8]
@@ -14,7 +14,6 @@ commands=
 deps =
     -r{toxinidir}/requirements-dev.txt
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
 


### PR DESCRIPTION
- Actually raise SyncRequestAlreadyProcessed() (#38)
- Avoid unnecessarily re-hashing the node data when committing
- Keep track of committed nodes