### PR TITLE
Piper/faster rlp insertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ fixtures/**
 
 # profiling
 prof/**
+
+# hypothesis
+.hypothesis

--- a/tests/speed.py
+++ b/tests/speed.py
@@ -1,0 +1,38 @@
+import time
+import random
+
+import itertools
+
+from trie import HexaryTrie
+
+
+def mk_random_bytes(n):
+    return bytes(bytearray([random.randint(0, 255) for _ in range(n)]))
+
+
+TEST_DATA = {
+    mk_random_bytes(i): mk_random_bytes(j)
+    for _ in range(128)
+    for i, j in itertools.product(range(1, 33, 4), range(1, 130, 8))
+}
+
+
+def main():
+    print('testing %s values' % len(TEST_DATA))
+    trie = HexaryTrie(db={})
+
+    st = time.time()
+    for k, v in sorted(TEST_DATA.items()):
+        trie[k] = v
+    elapsed = time.time() - st
+    print('time to insert %d - %.2f' % (len(TEST_DATA), elapsed))
+
+    st = time.time()
+    for k in sorted(TEST_DATA.keys()):
+        v = trie[k]
+    elapsed = time.time() - st
+    print('time to read %d - %.2f' % (len(TEST_DATA), elapsed))
+
+
+if __name__ == '__main__':
+    main()

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -1,6 +1,6 @@
 import itertools
 
-import rlp
+from rlp.codec import encode_raw
 
 from eth_utils import (
     keccak,
@@ -42,7 +42,7 @@ from trie.validation import (
 
 
 # sanity check
-assert BLANK_NODE_HASH == keccak(rlp.encode(b''))
+assert BLANK_NODE_HASH == keccak(encode_raw(b''))
 assert BLANK_HASH == keccak(b'')
 
 
@@ -161,7 +161,7 @@ class HexaryTrie(object):
     #
     def _set_root_node(self, root_node):
         validate_is_node(root_node)
-        encoded_root_node = rlp.encode(root_node)
+        encoded_root_node = encode_raw(root_node)
         self.root_hash = keccak(encoded_root_node)
         self.db[self.root_hash] = encoded_root_node
 
@@ -183,7 +183,7 @@ class HexaryTrie(object):
         validate_is_node(node)
         if is_blank_node(node):
             return BLANK_NODE
-        encoded_node = rlp.encode(node)
+        encoded_node = encode_raw(node)
         if len(encoded_node) < 32:
             return node
 


### PR DESCRIPTION
### What was wrong?

The RLP encoding on inserts could be faster.

### How was it fixed?

Used `rlp.codec.encode_raw` which only handles `bytes` and lists of `bytes`.

#### Baseline (current master @ de7b644d306c54f21092d7ed562a952c92940d08)

```
$ python tests/speed.py
testing 15488 values
time to insert 15488 - 11.46
time to read 15488 - 2.59
```
      
#### This branch

```
$ python tests/speed.py
testing 15488 values
time to insert 15488 - 7.05
time to read 15488 - 2.51
```

#### Cute Animal Picture

![cute_baby_camel_559707](https://user-images.githubusercontent.com/824194/38699575-9d01a7fa-3e55-11e8-8d5c-45a125ef2a23.jpg)

