### PR TITLE
don't mess with user's warning filters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def show_all_warnings():
+    warnings.simplefilter('always')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 

--- a/trie/__init__.py
+++ b/trie/__init__.py
@@ -11,13 +11,11 @@ from .hexary import (  # noqa: F401
 
 class Trie(HexaryTrie):
     def __init__(self, *args, **kwargs):
-        warnings.simplefilter('always', DeprecationWarning)
         warnings.warn(DeprecationWarning(
             "The `trie.Trie` class has been renamed to `trie.HexaryTrie`. "
             "Please update your code as the `trie.Trie` class will be removed in "
             "a subsequent release"
         ))
-        warnings.resetwarnings()
         super().__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
### What was wrong?

We shouldn't mess with the user's warning filters.

### How was it fixed?

Let user manage their own filters. Show all warnings during tests.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/70/04/21/700421ce8504b2491e6edd6e782a6f76.jpg)