### PR TITLE
Significantly reduce writes to DB

### DIFF
--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -8,11 +8,15 @@ import os
 from eth_utils import (
     is_0x_prefixed,
     decode_hex,
+    keccak,
     text_if_str,
     to_bytes,
 )
 
 from trie import HexaryTrie
+from trie.utils.nodes import (
+    decode_node,
+)
 
 
 def normalize_fixture(fixture):
@@ -61,7 +65,7 @@ RAW_FIXTURES = tuple(
 )
 
 
-FIXTURES = tuple(
+FIXTURES_NORMALIZED = tuple(
     (
         "{0}:{1}".format(fixture_filename, key),
         normalize_fixture(fixtures[key]),
@@ -71,11 +75,11 @@ FIXTURES = tuple(
 )
 
 
-@pytest.mark.parametrize(
-    'fixture_name,fixture', FIXTURES,
-)
-def test_trie_using_fixtures(fixture_name, fixture):
+def get_fixture_iterator(fixture):
+    return itertools.islice(itertools.permutations(fixture['in']), 100)
 
+
+def get_expected_results(fixture):
     keys_and_values = fixture['in']
     deletes = tuple(k for k, v in keys_and_values if v is None)
     remaining = {
@@ -84,28 +88,152 @@ def test_trie_using_fixtures(fixture_name, fixture):
         in keys_and_values
         if k not in deletes
     }
+    return remaining, deletes
 
-    for kv_permutation in itertools.islice(itertools.permutations(keys_and_values), 100):
-        print("in it")
-        trie = HexaryTrie(db={})
 
-        for key, value in kv_permutation:
-            if value is None:
-                del trie[key]
-            else:
-                trie[key] = value
-        for key in deletes:
+def permute_fixtures(fixtures):
+    for fixture_name, fixture in fixtures:
+        final_mapping, deleted_keys = get_expected_results(fixture)
+        final_root = fixture['root']
+        for update_series in itertools.islice(itertools.permutations(fixture['in']), 100):
+            yield (fixture_name, update_series, final_mapping, deleted_keys, final_root)
+
+
+FIXTURES_PERMUTED = tuple(permute_fixtures(FIXTURES_NORMALIZED))
+
+
+def trim_long_bytes(param):
+    if isinstance(param, bytes) and len(param) > 3:
+        return repr('0x' + param[:3].hex() + '...')
+
+
+@pytest.mark.parametrize(
+    'name, updates, expected, deleted, final_root',
+    FIXTURES_PERMUTED,
+    ids=trim_long_bytes,
+)
+def test_trie_using_fixtures(name, updates, expected, deleted, final_root):
+    trie = HexaryTrie(db={})
+
+    for key, value in updates:
+        if value is None:
             del trie[key]
+        else:
+            trie[key] = value
 
-        for key, expected_value in remaining.items():
-            assert key in trie
-            actual_value = trie[key]
-            assert actual_value == expected_value
+    for key in deleted:
+        del trie[key]
 
-        for key in deletes:
-            assert key not in trie
+    for key, expected_value in expected.items():
+        assert key in trie
+        actual_value = trie[key]
+        assert actual_value == expected_value
 
-        expected_root = fixture['root']
-        actual_root = trie.root_hash
+    for key in deleted:
+        assert key not in trie
 
-        assert actual_root == expected_root
+    actual_root = trie.root_hash
+    assert actual_root == final_root
+
+
+class KeyAccessLogger(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.read_keys = set()
+
+    def __getitem__(self, key):
+        result = super().__getitem__(key)
+        self.read_keys.add(key)
+        return result
+
+    def unread_keys(self):
+        return self.keys() - self.read_keys
+
+
+def test_hexary_trie_saves_each_root():
+    changes = ((b'ab', b'b'*32), (b'ac', b'c'*32), (b'ac', None), (b'ad', b'd'*32))
+    expected = ((b'ab', b'b'*32), (b'ad', b'd'*32))
+    db = {}
+    trie = HexaryTrie(db=db)
+    for key, val in changes:
+        if val is None:
+            del trie[key]
+        else:
+            trie[key] = val
+
+    # access all of the values in the trie, triggering reads for all the database keys
+    # that support the final state
+    flagged_usage_db = KeyAccessLogger(db)
+    flag_trie = HexaryTrie(flagged_usage_db, root_hash=trie.root_hash)
+    for key, val in expected:
+        assert flag_trie[key] == val
+
+    # the trie that doesn't prune will certainly have extra keys that aren't needed by
+    # the state with the final root_hash
+    unread = flagged_usage_db.unread_keys()
+    assert len(unread) > 0
+
+
+@pytest.mark.parametrize(
+    'name, updates, expected, deleted, final_root',
+    FIXTURES_PERMUTED,
+    ids=trim_long_bytes,
+)
+def test_hexary_trie_saving_final_root(name, updates, expected, deleted, final_root):
+    db = {}
+    trie = HexaryTrie(db=db)
+    with trie.squash_changes() as memory_trie:
+        for key, value in updates:
+            if value is None:
+                del memory_trie[key]
+            else:
+                memory_trie[key] = value
+
+        for key in deleted:
+            del memory_trie[key]
+
+    # access all of the values in the trie, triggering reads for all the database keys
+    # that support the final state
+    flagged_usage_db = KeyAccessLogger(db)
+    flag_trie = HexaryTrie(flagged_usage_db, root_hash=trie.root_hash)
+    for key, val in expected.items():
+        assert flag_trie[key] == val
+
+    # assert that no unnecessary database values were created
+    unread = flagged_usage_db.unread_keys()
+    straggler_data = {k: (db[k], decode_node(db[k])) for k in unread}
+    assert len(unread) == 0, straggler_data
+
+    actual_root = trie.root_hash
+    assert actual_root == final_root
+
+
+def test_hexary_trie_batch_save_keeps_last_root_data():
+    db = {}
+    trie = HexaryTrie(db)
+    trie.set(b'what floats on water?', b'very small rocks')
+    old_root_hash = trie.root_hash
+
+    with trie.squash_changes() as memory_trie:
+        memory_trie.set(b'what floats on water?', b'a duck')
+
+    assert trie[b'what floats on water?'] == b'a duck'
+
+    old_trie = HexaryTrie(db, root_hash=old_root_hash)
+    assert old_trie[b'what floats on water?'] == b'very small rocks'
+
+
+def test_hexary_trie_batch_save_drops_last_root_data_when_pruning():
+    db = {}
+    trie = HexaryTrie(db, prune=True)
+    trie.set(b'what floats on water?', b'very small rocks')
+    old_root_hash = trie.root_hash
+
+    with trie.squash_changes() as memory_trie:
+        memory_trie.set(b'what floats on water?', b'a duck')
+
+    assert trie[b'what floats on water?'] == b'a duck'
+
+    old_trie = HexaryTrie(db, root_hash=old_root_hash)
+    with pytest.raises(KeyError):
+        old_trie.root_node

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -8,7 +8,6 @@ import os
 from eth_utils import (
     is_0x_prefixed,
     decode_hex,
-    keccak,
     text_if_str,
     to_bytes,
 )
@@ -73,10 +72,6 @@ FIXTURES_NORMALIZED = tuple(
     for fixture_filename, fixtures in RAW_FIXTURES
     for key in sorted(fixtures.keys())
 )
-
-
-def get_fixture_iterator(fixture):
-    return itertools.islice(itertools.permutations(fixture['in']), 100)
 
 
 def get_expected_results(fixture):

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ basepython =
 [testenv:flake8]
 basepython=python
 deps=flake8
-commands=flake8 {toxinidir}/trie
+commands=flake8 {toxinidir}/trie {toxinidir}/tests

--- a/trie/utils/db.py
+++ b/trie/utils/db.py
@@ -1,0 +1,58 @@
+import contextlib
+
+
+class ScratchDB:
+    """
+    A wrapper of basic DB objects with uncommitted DB changes stored in local cache,
+    which represents as a dictionary of database keys and values.
+    None values cannot be represented, because they signify a deleted value.
+
+    The method batch_commit() can be used as a context manager.
+    Upon exiting the context, it writes all of the key value pairs from the cache into
+    the underlying database. It optionally pushes deletes to the underlying databes.
+    If any exception occurrs before committing phase, no changes are applied.
+    """
+    def __init__(self, wrapped_db):
+        self.wrapped_db = wrapped_db
+        self.cache = {}
+
+    #
+    # Dictionary API
+    #
+    # if not key is found, return None
+    def __getitem__(self, key):
+        if key in self.cache:
+            return self.cache[key]
+        else:
+            return self.wrapped_db.get(key, None)
+
+    def __setitem__(self, key, value):
+        self.cache[key] = value
+
+    def __delitem__(self, key):
+        self.cache[key] = None
+
+    def __contains__(self, key):
+        if key in self.cache:
+            return self.cache[key] is not None
+        else:
+            return key in self.wrapped_db
+
+    @contextlib.contextmanager
+    def batch_commit(self, *, do_deletes=False):
+        '''
+        Batch and commit and end of context
+        '''
+        try:
+            yield
+        except Exception as exc:
+            raise exc
+        else:
+            for key, value in self.cache.items():
+                if value is not None:
+                    self.wrapped_db[key] = value
+                elif do_deletes:
+                    self.wrapped_db.pop(key, None)
+                # if do_deletes is False, ignore deletes to underlying db
+        finally:
+            self.cache = {}


### PR DESCRIPTION
When using the new `trie.squash_changes()` context, the `HexaryTrie` will automatically prune all database changes that don't make it into the final root.

### What was wrong?

As the trie adds & removes keys, it stores all the state in the database. It also stores all of the state generated inside a single `set()`, when modifying each node that it needs to touch, even when that state is unreachable by the end of the action. This creates a lot of cruft data that is hard to track down, and increases write volume significantly.

### How was it fixed?

Added a new `prune` flag which aggressively removes *all* old node data. To batch up changes, and throw out the data generated along the way, use the new context manager, like:

```py
trie = HexaryTrie(HypotheticalDiskDatabase())

with trie.squash_changes() as squashing_trie:
    squashing_trie[key1] = val1
    squashing_trie[key2] = val2
    del squashing_trie[key3]
```

The two state roots (after `key1` and `key2`), and in fact **all** of the nodes created and unreachable from the latest state root, are never pushed to the database on disk. See `test_hexary_trie_saving_final_root()` which tests that all unreachable fields have been pruned away.

`ScratchDB` was largely lifted from https://github.com/jannikluhn/py-evm/commit/40e46121eaba893997976ebd08fbbf5f3a9e885e -- thanks @sunxivincent

#### Cute Animal Picture

![Cute animal picture](http://www.cutestpaw.com/wp-content/uploads/2014/04/s-Penguin-puff.jpg)
