### PR TITLE
test against 1.0.0 pyrlp library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ matrix:
       env: TOX_POSARGS="-e flake8"
     # core
     - python: "3.5"
-      env: TOX_POSARGS="-e py35"
+      env: TOX_POSARGS="-e py35-rlp0"
     - python: "3.6"
-      env: TOX_POSARGS="-e py36"
+      env: TOX_POSARGS="-e py36-rlp1"
+    - python: "3.5"
+      env: TOX_POSARGS="-e py35-rlp0"
+    - python: "3.6"
+      env: TOX_POSARGS="-e py36-rlp1"
 cache:
   pip: true
 install:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     install_requires=[
         "eth-utils>=1.0.0,<2.0.0",
-        "rlp>=0.4.7,<1.0.0",
+        "rlp>=0.4.7,<2.0.0",
         "cytoolz>=0.8.0,<1",
     ],
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36}
+    py{35,36}-rlp{0,1}
     flake8
 
 [flake8]
@@ -13,6 +13,8 @@ commands=
     py.test {posargs:tests}
 deps =
     -r{toxinidir}/requirements-dev.txt
+    rlp0: rlp>=0.4.7,<1
+    rlp1: rlp>=1,<2
 basepython =
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
### What was wrong

The `rlp` library has a major point release which is compatible with how `py-trie` uses it.

### How was it fixed.

Expand the version range and add testing for both major version ranges.