### PR TITLE
fixes #53

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ common: &common
         command: ~/.local/bin/tox
     - save_cache:
         paths:
+          - .hypothesis
           - .tox
           - ~/.cache/pip
           - ~/.local

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,10 +16,19 @@ from .utils import make_random_trie
 logger = logging.getLogger()
 
 
+# produces a branch node with an extention node who's encoding is less than 32
+# bytes in length so it is inlined.
+EXAMPLE_37968 = 37968
+
+# produces an top level extension node who's encoding is less than 32 bytes in
+# length so it gets inlined.
+EXAMPLE_809368 = 809368
+
+
 @given(random=strategies.randoms())
 @settings(max_examples=50)
-@example(random=RandomWithSeed(37968))
-@example(random=RandomWithSeed(809368))
+@example(random=RandomWithSeed(EXAMPLE_37968))
+@example(random=RandomWithSeed(EXAMPLE_809368))
 def test_trie_sync(random):
     src_trie, contents = make_random_trie(random)
 
@@ -29,11 +38,7 @@ def test_trie_sync(random):
     while len(requests) > 0:
         results = []
         for request in requests:
-            if len(request.node_key) == 32:
-                results.append([request.node_key, src_trie.db[request.node_key]])
-            else:
-                import rlp
-                results.append([request.node_key, rlp.decode(request.node_key)])
+            results.append([request.node_key, src_trie.db[request.node_key]])
         scheduler.process(results)
         requests = scheduler.next_batch(10)
     dest_trie = HexaryTrie(dest_db, src_trie.root_hash)

--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -24,7 +24,3 @@ class InvalidKeyError(Exception):
 
 class SyncRequestAlreadyProcessed(Exception):
     pass
-
-
-class UnexpectedNodeType(Exception):
-    pass

--- a/trie/iter.py
+++ b/trie/iter.py
@@ -4,9 +4,6 @@ from trie.constants import (
     NODE_TYPE_EXTENSION,
     NODE_TYPE_BRANCH,
 )
-from trie.exceptions import (
-    InvalidNode,
-)
 from trie.utils.nibbles import (
     bytes_to_nibbles,
     nibbles_to_bytes,
@@ -55,7 +52,7 @@ class NodeIterator:
                     return (i,) + nibbles
             raise Exception("Invariant: this means we have an empty branch node")
         else:
-            raise InvalidNode("Unexpected node type: %s" % node_type)
+            raise Exception("Invariant: unknown node type {0}".format(node))
 
     def _iter(self, node, key):
         node_type = get_node_type(node)


### PR DESCRIPTION
### What was wrong?

The `HexaryTrieSync` was coded primarily to support the primary use case, syncing the ethereum state trie.  Because of this, it was written to not support certain key/value types that won't appear in the ethereum state trie because of the way that keys and values are encoded.

however, our fuzz testing ran into this case and caused CI failures.

### How was it fixed?

Went ahead and added support for nodes who's RLP encoding is less than 32 bytes and thus, rather than being referenced, they are actually inlined.

#### Cute Animal Picture

![cute-camel](https://user-images.githubusercontent.com/824194/39322013-c98422a8-4945-11e8-8974-479dc84a5ced.jpg)

