### PR TITLE
Use eth_hash.auto for keccak instead of eth_utils

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ tox==2.6.0
 pytest==3.0.7
 hypothesis==3.7.0
 bumpversion==0.5.3
-eth-hash[pycryptodome]>=0.1.0a4,<1.0.0
+eth-hash[pycryptodome]>=0.1.0,<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     py_modules=['trie'],
     setup_requires=['setuptools-markdown'],
     install_requires=[
+        "eth-hash>=0.1.0,<1.0.0",
         "eth-utils>=1.0.0,<2.0.0",
         "rlp>=0.4.7,<2.0.0",
         "cytoolz>=0.8.0,<1",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
-        "eth-utils>=1.0.0,<2.0.0",
+        "eth-utils>=1.0.1,<2.0.0",
         "rlp>=0.4.7,<2.0.0",
         "cytoolz>=0.8.0,<1",
     ],

--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eth_utils import (
+from eth_hash.auto import (
     keccak,
 )
 

--- a/trie/binary.py
+++ b/trie/binary.py
@@ -1,4 +1,4 @@
-from eth_utils import (
+from eth_hash.auto import (
     keccak,
 )
 

--- a/trie/branches.py
+++ b/trie/branches.py
@@ -1,4 +1,4 @@
-from eth_utils import (
+from eth_hash.auto import (
     keccak,
 )
 

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -3,7 +3,7 @@ import itertools
 
 from rlp.codec import encode_raw
 
-from eth_utils import (
+from eth_hash.auto import (
     keccak,
 )
 


### PR DESCRIPTION
### What was wrong?

Fixes #55 

### How was it fixed?

Switch from the `eth_utils` keccak function to the `eth_hash.auto`  keccak function.

**NOTE:**
Due to this issue - ethereum/eth-utils#74 - I've bumped the minimum version for eth-utils to 1.0.1[1] and the minimum for eth-hash to 0.1.0 to ensure the dependencies are aligned.

[1] ethereum/eth-utils@dbc4e7c

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/6325996/40582648-5efbe834-6142-11e8-88ac-2a16c5c143a8.jpg)
