### PR TITLE
Improve the performance of HexaryTrie._prune_node()

### DIFF
--- a/tests/speed.py
+++ b/tests/speed.py
@@ -1,5 +1,7 @@
-import time
+import cProfile
+import pstats
 import random
+import time
 
 import itertools
 
@@ -17,21 +19,49 @@ TEST_DATA = {
 }
 
 
-def main():
-    print('testing %s values' % len(TEST_DATA))
+def _insert_test():
     trie = HexaryTrie(db={})
-
-    st = time.time()
     for k, v in sorted(TEST_DATA.items()):
         trie[k] = v
-    elapsed = time.time() - st
-    print('time to insert %d - %.2f' % (len(TEST_DATA), elapsed))
+    return trie
 
-    st = time.time()
-    for k in sorted(TEST_DATA.keys()):
-        v = trie[k]
-    elapsed = time.time() - st
-    print('time to read %d - %.2f' % (len(TEST_DATA), elapsed))
+
+def _insert_squash_test():
+    trie = HexaryTrie(db={})
+    with trie.squash_changes() as memory_trie:
+        for k, v in sorted(TEST_DATA.items()):
+            memory_trie[k] = v
+    return trie
+
+
+def main(profile=True):
+    print('testing %s values' % len(TEST_DATA))
+    tests = [
+        ('insert', _insert_test),
+        ('insert squash', _insert_squash_test),
+    ]
+    for name, func in tests:
+        profiler = cProfile.Profile()
+        if profile:
+            profiler.enable()
+
+        st = time.time()
+        trie = func()
+        elapsed = time.time() - st
+        print('time to %s %d - %.2f' % (name, len(TEST_DATA), elapsed))
+
+        if profile:
+            print("==== Profiling stats for %s test =========" % name)
+            profiler.disable()
+            stats = pstats.Stats(profiler)
+            stats.strip_dirs().sort_stats('cumulative').print_stats(30)
+            print("==========================================")
+
+        st = time.time()
+        for k in sorted(TEST_DATA.keys()):
+            trie[k]
+        elapsed = time.time() - st
+        print('time to read %d - %.2f' % (len(TEST_DATA), elapsed))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
That's achieved by using an LRU cache on _node_to_db_mapping()

Before the change:
> 43304441 function calls (40363571 primitive calls) in 22.178 seconds
> 68699    0.108    0.000    7.555    0.000 hexary.py:237(_prune_node)

After the change:
> 38196529 function calls (35857163 primitive calls) in 19.180 seconds
> 68633    0.097    0.000    3.109    0.000 hexary.py:236(_prune_node)

(Number of _prune_node() calls is not identical because the test uses random data)