### PR TITLE
remove support for rlp 0.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,13 +27,13 @@ common: &common
           fi
     - restore_cache:
         keys:
-          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox
+        command: ~/.local/bin/tox -r
     - save_cache:
         paths:
           - .hypothesis
@@ -41,60 +41,46 @@ common: &common
           - ~/.cache/pip
           - ~/.local
           - ./eggs
-        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  lint:
+  py35-lint:
     <<: *common
     docker:
       - image: circleci/python:3.5
         environment:
           TOXENV: lint
-  py35-rlp0:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-rlp0
-  py35-rlp1:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-rlp1
-  py36-rlp0:
+  py36-lint:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-rlp0
-  py36-rlp1:
+          TOXENV: lint
+  py35:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35
+  py36:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-rlp1
-  pypy3-rlp0:
+          TOXENV: py36
+  pypy3:
     <<: *common
     docker:
       - image: pypy
         environment:
-          TOXENV: pypy3-rlp0
-  pypy3-rlp1:
-    <<: *common
-    docker:
-      - image: pypy
-        environment:
-          TOXENV: pypy3-rlp1
+          TOXENV: pypy3
 
 workflows:
   version: 2
   test:
     jobs:
-      - lint
-      - py35-rlp0
-      - py35-rlp1
-      - py36-rlp0
-      - py36-rlp1
-      - pypy3-rlp0
-      - pypy3-rlp1
+      - py35-lint
+      - py36-lint
+      - py35
+      - py36
+      - pypy3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras_require = {
 extras_require['dev'] = (
     extras_require['dev'] +
     extras_require['test'] +
-    extras_require['lint'] 
+    extras_require['lint']
 )
 
 setup(
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
         "eth-utils>=1.0.1,<2.0.0",
-        "rlp>=0.4.7,<2.0.0",
+        "rlp>=1,<2",
         "cytoolz>=0.8.0,<1",
     ],
     extras_require=extras_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-  py{35,36,py3}-rlp{0,1}
-  lint
+  py{35,36,py3}
+  py{35,36}-lint
 
 [flake8]
 max-line-length = 100
@@ -11,9 +11,6 @@ exclude=
 usedevelop=True
 commands=
   py.test {posargs:tests}
-deps =
-  rlp0: rlp>=0.4.7,<1
-  rlp1: rlp>=1,<2
 basepython =
   py35: python3.5
   py36: python3.6
@@ -22,5 +19,5 @@ extras = test
 
 [testenv:lint]
 basepython=python
-deps=flake8
+extras = lint
 commands=flake8 {toxinidir}/trie {toxinidir}/tests


### PR DESCRIPTION
### What was wrong?

Legacy support for an old version of the rlp library.

### How was it fixed?

Removed tests for it.

#### Cute Animal Picture

![Cute animal picture]()
