### PR TITLE
Add `get_proof`

### DIFF
--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -133,13 +133,13 @@ def test_trie_using_fixtures(name, updates, expected, deleted, final_root):
     for valid_proof_key in expected:
         valid_proof = trie.get_proof(valid_proof_key)
         assert len(valid_proof) > 0
-        print(valid_proof)
+
         valid_proof_value = HexaryTrie.get_from_proof(trie.root_hash, valid_proof_key, valid_proof)
         assert valid_proof_value == trie.get(valid_proof_key)
 
     for invalid_proof_key in deleted:
-        invalid_proof = trie.get_proof(invalid_proof_key)
-        assert len(invalid_proof) == 0
+        with pytest.raises(KeyError):
+            trie.get_proof(invalid_proof_key)
 
 
 class KeyAccessLogger(dict):

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -130,6 +130,17 @@ def test_trie_using_fixtures(name, updates, expected, deleted, final_root):
     actual_root = trie.root_hash
     assert actual_root == final_root
 
+    for valid_proof_key in expected:
+        valid_proof = trie.get_proof(valid_proof_key)
+        assert len(valid_proof) > 0
+        print(valid_proof)
+        valid_proof_value = HexaryTrie.get_from_proof(trie.root_hash, valid_proof_key, valid_proof)
+        assert valid_proof_value == trie.get(valid_proof_key)
+
+    for invalid_proof_key in deleted:
+        invalid_proof = trie.get_proof(invalid_proof_key)
+        assert len(invalid_proof) == 0
+
 
 class KeyAccessLogger(dict):
     def __init__(self, *args, **kwargs):

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -159,7 +159,10 @@ class HexaryTrie:
 
         proof = []
         verified = self._get_proof(node, trie_key, proof)
-        return tuple(proof) if verified else ()
+        if verified:
+            return tuple(proof)
+        else:
+            raise KeyError("Key does not exist")
 
     def _get_proof(self, node, trie_key, proof):
         proof.append(node)

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -180,17 +180,17 @@ class HexaryTrie:
         elif node_type == NODE_TYPE_EXTENSION:
             current_key = extract_key(node)
             if key_starts_with(unproven_key, current_key):
-                node = self.get_node(node[1])
+                next_node = self.get_node(node[1])
                 new_proven_len = proven_len + len(current_key)
-                return self._get_proof(node, trie_key, new_proven_len, updated_proof)
+                return self._get_proof(next_node, trie_key, new_proven_len, updated_proof)
             else:
                 raise self._missing_key_error(trie_key)
         elif node_type == NODE_TYPE_BRANCH:
             if not unproven_key:
                 return updated_proof
-            node = self.get_node(node[unproven_key[0]])
+            next_node = self.get_node(node[unproven_key[0]])
             new_proven_len = proven_len + 1
-            return self._get_proof(node, trie_key, new_proven_len, updated_proof)
+            return self._get_proof(next_node, trie_key, new_proven_len, updated_proof)
         else:
             raise Exception("Invariant: This shouldn't ever happen")
 

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -167,12 +167,10 @@ class HexaryTrie:
         node_type = get_node_type(node)
         if node_type == NODE_TYPE_BLANK:
             return False
-
-        if node_type == NODE_TYPE_LEAF:
+        elif node_type == NODE_TYPE_LEAF:
             current_key = extract_key(node)
             return current_key == trie_key
-
-        if node_type == NODE_TYPE_EXTENSION:
+        elif node_type == NODE_TYPE_EXTENSION:
             current_key = extract_key(node)
             if key_starts_with(trie_key, current_key):
                 node = self.get_node(node[1])
@@ -180,16 +178,14 @@ class HexaryTrie:
                 return self._get_proof(node, trie_key, proof)
             else:
                 return False
-
-        if node_type == NODE_TYPE_BRANCH:
+        elif node_type == NODE_TYPE_BRANCH:
             if not trie_key:
                 return True
-
             node = self.get_node(node[trie_key[0]])
             trie_key = trie_key[1:]
             return self._get_proof(node, trie_key, proof)
-
-        raise Exception("Invariant: This shouldn't ever happen")
+        else:
+            raise Exception("Invariant: This shouldn't ever happen")
 
     #
     # Convenience


### PR DESCRIPTION
### What was wrong?
- There was not `get_proof` even if `get_from_proof` exists.
- `get_from_proof` had a problem that a trie could not add a node less than 32 bytes as a proof.

### How was it fixed?
- I made `get_proof` method.
- Add proof nodes to db by force in `get_from_proof`


#### Cute Animal Picture

![Cute animal picture](http://file.instiz.net/data/cached_img/upload/6/1/f/61ffb6db70ae1bbd4df22c2083dbeeb3.jpg)
