### PR TITLE
Remove explicit pytest requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup, find_packages
 
 extras_require = {
     'test': [
-        "pytest==3.0.7",
         "pytest-xdist",
         "tox>=2.6.0,<3",
         "hypothesis==3.7.0",


### PR DESCRIPTION
### What was wrong?

`pytest-xdist` has specific `pytest` requirements

### How was it fixed?

Remove pinned `pytest` requirement, allow `pytest-xdist` to choose which `pytest` to install.

#### Cute Animal Picture

![Cute animal picture](http://www.takepart.com/sites/default/files/styles/tp_gallery_slide/public/5-Milne-Edwards-Sportive-Lemur-620-itok=3KSwonb3.jpg)
