### PR TITLE
Could not be added a node less than 32 bytes in `get_from_proof` 

### DIFF
--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -31,14 +31,3 @@ def test_get_from_proof_empty():
     proof = []
     with pytest.raises(BadTrieProof):
         HexaryTrie.get_from_proof(state_root, key, proof)
-
-
-def test_get_from_proof_node_less_than_32bytes():
-    t = HexaryTrie(db={})
-    t[b'some key'] = b'some value'
-    proof1 = t.get_proof(b'some key')
-    assert HexaryTrie.get_from_proof(t.root_hash, b'some key', proof1) == b'some value'
-
-    t[b'some key2'] = b'some value2'
-    proof2 = t.get_proof(b'some key2')
-    assert HexaryTrie.get_from_proof(t.root_hash, b'some key2', proof2) == b'some value2'

--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -31,3 +31,18 @@ def test_get_from_proof_empty():
     proof = []
     with pytest.raises(BadTrieProof):
         HexaryTrie.get_from_proof(state_root, key, proof)
+
+
+def test_get_from_proof_node_less_than_32bytes():
+    t = HexaryTrie(db={})
+    t[b'some key'] = b'some value'
+    assert HexaryTrie.get_from_proof(t.root_hash, b'some key', [t.root_node]) == b'some value'
+
+    t[b'some key2'] = b'some value2'
+
+    proof = [
+        t.root_node,
+        [b'', b'', b'', [b'2', b'some value2'], b'', b'', b'',
+         b'', b'', b'', b'', b'', b'', b'', b'', b'', b'some value']
+    ]
+    assert HexaryTrie.get_from_proof(t.root_hash, b'some key2', proof) == b'some value2'

--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -36,13 +36,9 @@ def test_get_from_proof_empty():
 def test_get_from_proof_node_less_than_32bytes():
     t = HexaryTrie(db={})
     t[b'some key'] = b'some value'
-    assert HexaryTrie.get_from_proof(t.root_hash, b'some key', [t.root_node]) == b'some value'
+    proof1 = t.get_proof(b'some key')
+    assert HexaryTrie.get_from_proof(t.root_hash, b'some key', proof1) == b'some value'
 
     t[b'some key2'] = b'some value2'
-
-    proof = [
-        t.root_node,
-        [b'', b'', b'', [b'2', b'some value2'], b'', b'', b'',
-         b'', b'', b'', b'', b'', b'', b'', b'', b'', b'some value']
-    ]
-    assert HexaryTrie.get_from_proof(t.root_hash, b'some key2', proof) == b'some value2'
+    proof2 = t.get_proof(b'some key2')
+    assert HexaryTrie.get_from_proof(t.root_hash, b'some key2', proof2) == b'some value2'

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -215,7 +215,8 @@ class HexaryTrie:
             return BLANK_NODE_HASH
 
         if value is None:
-            # some nodes
+            # Some nodes are so small that they are not encoded during _node_to_db_mapping,
+            # so we manually encode and hash it here:
             encoded_node = encode_raw(key)
             node_hash = keccak(encoded_node)
         else:

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -142,13 +142,10 @@ class HexaryTrie:
     #
     @classmethod
     def get_from_proof(cls, root_hash, key, proof):
-        db = {}
-        for node in proof:
-            encoded_node = encode_raw(node)
-            encoded_node_hash = keccak(encoded_node)
-            db[encoded_node_hash] = encoded_node
+        trie = cls({})
 
-        trie = cls(db)
+        for node in proof:
+            trie._set_raw_node(node)
         trie.root_hash = root_hash
         try:
             return trie.get(key)
@@ -211,6 +208,23 @@ class HexaryTrie:
     #
     # Utils
     #
+    def _set_raw_node(self, raw_node):
+        key, value = self._node_to_db_mapping(raw_node)
+        if key == BLANK_NODE:
+            # skip saving the blank node to DB
+            return BLANK_NODE_HASH
+
+        if value is None:
+            # some nodes
+            encoded_node = encode_raw(key)
+            node_hash = keccak(encoded_node)
+        else:
+            encoded_node = value
+            node_hash = key
+
+        self.db[node_hash] = encoded_node
+        return node_hash
+
     def _set_root_node(self, root_node):
         validate_is_node(root_node)
         if self.is_pruning:
@@ -218,13 +232,7 @@ class HexaryTrie:
             if old_root_hash != BLANK_NODE_HASH and old_root_hash in self.db:
                 del self.db[old_root_hash]
 
-        if is_blank_node(root_node):
-            self.root_hash = BLANK_NODE_HASH
-        else:
-            encoded_root_node = encode_raw(root_node)
-            new_root_hash = keccak(encoded_root_node)
-            self.db[new_root_hash] = encoded_root_node
-            self.root_hash = new_root_hash
+        self.root_hash = self._set_raw_node(root_node)
 
     def get_node(self, node_hash):
         if node_hash == BLANK_NODE:

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -142,10 +142,13 @@ class HexaryTrie:
     #
     @classmethod
     def get_from_proof(cls, root_hash, key, proof):
-        trie = cls({})
-
+        db = {}
         for node in proof:
-            trie._persist_node(node)
+            encoded_node = encode_raw(node)
+            encoded_node_hash = keccak(encoded_node)
+            db[encoded_node_hash] = encoded_node
+
+        trie = cls(db)
         trie.root_hash = root_hash
         try:
             return trie.get(key)


### PR DESCRIPTION
### What was wrong?
Test codes. I used parts of README.md
```python
from trie import HexaryTrie

t = HexaryTrie(db={})
t.set(b'my-key', b'some-value')

HexaryTrie.get_from_proof(t.root_hash, b'my-key', [t.root_node])  # BadTrieProof
```
It was mentioned in #80 


### How was it fixed?
As I understand it, 'proof' of a node consists of path nodes to the node from root node. So in my opinion we can push the path nodes to trie made temporary for proof without additional logic.
In the current codes `_persiste_node` prevents inserting path nodes less than 32 bytes. I think there are potential risks even if it covers most cases.


#### Cute Animal Picture

![Cute animal picture](http://d1841mjet2hm8m.cloudfront.net/thumb-900/fr_1099/1620/98/ab0fd44ddb9b8c031bb886c0748f4c70.jpg)
