### PR TITLE
More info when database is missing a node, plus related pruning bugfix

### DIFF
--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -1,3 +1,8 @@
+from eth_utils import (
+    encode_hex,
+)
+
+
 class InvalidNibbles(Exception):
     pass
 
@@ -24,3 +29,43 @@ class InvalidKeyError(Exception):
 
 class SyncRequestAlreadyProcessed(Exception):
     pass
+
+
+class MissingTrieNode(KeyError):
+    """
+    Raised when a node of the trie is not available in the database,
+    for the given key in the current state root.
+
+    Subclasses KeyError for backwards compatibility.
+    """
+    def __init__(self, missing_node_hash, root_hash, requested_key):
+        if not isinstance(missing_node_hash, bytes):
+            raise TypeError("Missing node hash must be bytes, was: %r" % missing_node_hash)
+        elif not isinstance(root_hash, bytes):
+            raise TypeError("Root hash must be bytes, was: %r" % root_hash)
+        elif not isinstance(requested_key, bytes):
+            raise TypeError("Requested key must be bytes, was: %r" % requested_key)
+
+        super().__init__(missing_node_hash, root_hash, requested_key)
+
+    def __repr__(self):
+        return "MissingTrieNode: {}".format(self)
+
+    def __str__(self):
+        return "Trie database is missing hash {} needed to look up key {} at root hash {}".format(
+            encode_hex(self.missing_node_hash),
+            encode_hex(self.requested_key),
+            encode_hex(self.root_hash),
+        )
+
+    @property
+    def missing_node_hash(self):
+        return self.args[0]
+
+    @property
+    def root_hash(self):
+        return self.args[1]
+
+    @property
+    def requested_key(self):
+        return self.args[2]


### PR DESCRIPTION
### What was wrong?

When a node in the trie was missing, we:
1. got relatively little information back about what happened
2. would prune nodes *before* attempting to set/delete, so extra trie elements would disappear

### How was it fixed?

- Add a custom exception for a missing trie node
- Include information in the exception like the root hash, the key requested, and the hash of the node missing
- Add tests that uncovered pruning bug
- Fix pruning bug

TODO
- [x] Debug what appears to be situations where pruning is incomplete
- [x] Remove type check from custom exception (or maybe improve the error message and add it to all values?)

#### Cute Animal Picture

![Cute animal picture](https://dingo.care2.com/pictures/c2c/share/25/258/830/2583066_370.jpg)
