### PR TITLE
Root specific lookup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Unreleased
+--------------
+
+* New `with trie.at_root(hash) as snapshot:` context API, to look up values on a
+  different root hash (https://github.com/ethereum/py-trie/pull/84)
+
 1.3.8
 --------
 

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -1,19 +1,21 @@
-import pytest
-
-import itertools
+from collections import defaultdict
 import fnmatch
+import itertools
 import json
 import os
 
 from eth_utils import (
+    ValidationError,
     is_0x_prefixed,
     decode_hex,
     encode_hex,
     text_if_str,
     to_bytes,
 )
+import pytest
 
 from trie import HexaryTrie
+from trie.constants import BLANK_NODE_HASH
 from trie.exceptions import MissingTrieNode
 from trie.utils.nodes import (
     decode_node,
@@ -166,13 +168,20 @@ class KeyAccessLogger(dict):
 def test_hexary_trie_saves_each_root():
     changes = ((b'ab', b'b'*32), (b'ac', b'c'*32), (b'ac', None), (b'ad', b'd'*32))
     expected = ((b'ab', b'b'*32), (b'ad', b'd'*32))
+
+    # track which key is expected to be present in which root
+    expected_by_root = defaultdict(set)
+    missing_by_root = defaultdict(set)
+
     db = {}
     trie = HexaryTrie(db=db)
     for key, val in changes:
         if val is None:
             del trie[key]
+            missing_by_root[trie.root_hash].add(key)
         else:
             trie[key] = val
+            expected_by_root[trie.root_hash].add((key, val))
 
     # access all of the values in the trie, triggering reads for all the database keys
     # that support the final state
@@ -185,6 +194,19 @@ def test_hexary_trie_saves_each_root():
     # the state with the final root_hash
     unread = flagged_usage_db.unread_keys()
     assert len(unread) > 0
+
+    # check that the values are still reachable at the old state roots
+    for root_hash, expected_items in expected_by_root.items():
+        for key, val in expected_items:
+            with trie.at_root(root_hash) as snapshot:
+                assert key in snapshot
+                assert snapshot[key] == val
+
+    # check that missing values are not reachable at the old state roots
+    for root_hash, missing_keys in missing_by_root.items():
+        for key in missing_keys:
+            with trie.at_root(root_hash) as snapshot:
+                assert key not in snapshot
 
 
 @pytest.mark.parametrize(
@@ -316,3 +338,12 @@ def test_hexary_trie_missing_node():
 
     # Other keys are still accessible
     assert trie.get(key2) == b'val2'
+
+
+def test_hexary_trie_raises_on_pruning_snapshot():
+    db = {}
+    trie = HexaryTrie(db, prune=True)
+
+    with pytest.raises(ValidationError):
+        with trie.at_root(BLANK_NODE_HASH):
+            pass

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -9,7 +9,6 @@ from eth_hash.auto import (
 )
 
 from eth_utils import (
-    ValidationError,
     to_list,
     to_tuple,
 )
@@ -25,6 +24,7 @@ from trie.constants import (
 from trie.exceptions import (
     BadTrieProof,
     MissingTrieNode,
+    ValidationError,
 )
 from trie.utils.db import (
     ScratchDB,
@@ -169,11 +169,12 @@ class HexaryTrie:
 
         for node in proof:
             trie._set_raw_node(node)
-        trie.root_hash = root_hash
-        try:
-            return trie.get(key)
-        except KeyError as e:
-            raise BadTrieProof("Missing proof node with hash {}".format(e.args))
+
+        with trie.at_root(root_hash) as proven_snapshot:
+            try:
+                return proven_snapshot.get(key)
+            except KeyError as e:
+                raise BadTrieProof("Missing proof node with hash {}".format(e.args))
 
     def get_proof(self, key):
         validate_is_bytes(key)


### PR DESCRIPTION
### What was wrong?

Want to look up the data in a node without first switching the root hash, eg, update API from:

```py
original_root_hash = trie.root_hash
trie.root_hash = target_root_hash
assert trie.get(key) == expected_value_at_target_hash
trie.root_hash = original_root_hash
```

to:
```py
assert trie.get(key, target_root_hash) == expected_value_at_target_hash
```

### How was it fixed?

~~Builds on #83 -- this review can focus on just the last two commits (bf726c and e0c7ff5 currently) and I won't merge until #83 is approved.~~

Dropped a few places where `HexaryTrie` was relying on `self.root_hash` exclusively. Keep the old behavior for backwards compatibility.

Extended a current test for checking values against old roots.

#### Cute Animal Picture

![Cute animal picture](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSjqYYK1W_idKdlL4uqkxook4flCjdUDhaC1Hsn7bPCDyxN_b5w)
