### PR TITLE
Cleanup missing trie node

### DIFF
--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -38,7 +38,7 @@ class MissingTrieNode(KeyError):
 
     Subclasses KeyError for backwards compatibility.
     """
-    def __init__(self, missing_node_hash, root_hash, requested_key):
+    def __init__(self, missing_node_hash, root_hash, requested_key, *args):
         if not isinstance(missing_node_hash, bytes):
             raise TypeError("Missing node hash must be bytes, was: %r" % missing_node_hash)
         elif not isinstance(root_hash, bytes):
@@ -46,7 +46,7 @@ class MissingTrieNode(KeyError):
         elif not isinstance(requested_key, bytes):
             raise TypeError("Requested key must be bytes, was: %r" % requested_key)
 
-        super().__init__(missing_node_hash, root_hash, requested_key)
+        super().__init__(missing_node_hash, root_hash, requested_key, *args)
 
     def __repr__(self):
         return "MissingTrieNode: {}".format(self)

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -239,20 +239,15 @@ class HexaryTrie:
         if self.is_pruning:
             # node is mutable, so capture the key for later pruning now
             prune_key, node_body = self._node_to_db_mapping(node)
+            should_prune = (node_body is not None)
         else:
-            node_body = None
+            should_prune = False
 
-        # Nothing to prune
-        if node_body is None:
-            yield
-        else:
-            # Prune only if no exception is raised
-            try:
-                yield
-            except:
-                raise
-            else:
-                del self.db[prune_key]
+        yield
+
+        # Prune only if no exception is raised
+        if should_prune:
+            del self.db[prune_key]
 
     def _set_raw_node(self, raw_node):
         key, value = self._node_to_db_mapping(raw_node)


### PR DESCRIPTION
### What was wrong?

Some cleanups from #83, and wanted to make `MissingTrieNode` cleaner to subclass.

Big picture: these are changes needed in py-trie for changes needed in py-evm to enable the next syncing approach being built in trinity. (a "fade in" state sync)

### How was it fixed?

- just `yield` then `prune` rather than explicitly add the "try / except / else"
- accept more arguments in `MissingTrieNode`

#### Cute Animal Picture

![Cute animal picture](https://2.bp.blogspot.com/-0TJ3_CdCbKc/WjMzHS2MKoI/AAAAAAAAW8E/oNPksdXT2yUAvzHg2nRtZb-jNlH3mxA5gCLcBGAs/s1600/fc025d329229ab71073e66895e25ed43--funniest-pictures-funny-photos.jpg)
