### PR TITLE
[WIP] Trie diff

### DIFF
--- a/tests/test_hexary_diff.py
+++ b/tests/test_hexary_diff.py
@@ -1,0 +1,96 @@
+import pytest
+
+from trie import HexaryTrie
+from trie.utils.db import (
+    KeyAccessLogger,
+)
+
+
+@pytest.mark.parametrize(
+    'items1, items2, expected_key_diffs',
+    (
+        ([], [], {}),
+        (
+            [(b'a', b'A')],
+            [],
+            {b'a': (b'A', None)},
+        ),
+        (
+            [],
+            [(b'a', b'A')],
+            {b'a': (None, b'A')},
+        ),
+        (
+            [(b'a', b'A')],
+            [(b'b', b'B')],
+            {b'a': (b'A', None), b'b': (None, b'B')},
+        ),
+        (
+            [(b'aa', b'A')],
+            [(b'aa', b'A'), (b'ab', b'B')],
+            {b'ab': (None, b'B')},
+        ),
+        (
+            [(b'\x0a', b'A'), (b'\x1a', b'B')],
+            [(b'\x0a', b'A'), (b'\x1a', b'B'), (b'\x2a', b'C')],
+            {b'\x2a': (None, b'C')},
+        ),
+        (
+            [(b'\x0a', b'A'), (b'\x0b', b'B')],
+            [(b'\x0ac', b'C')],
+            {
+                b'\x0a': (b'A', None),
+                b'\x0b': (b'B', None),
+                b'\x0ac': (None, b'C'),
+            },
+        ),
+        (
+            [(b'\x0a', b'A' * 33), (b'\x0b', b'B' * 33)],
+            [(b'\x0ac', b'C' * 33)],
+            {
+                b'\x0a': (b'A' * 33, None),
+                b'\x0b': (b'B' * 33, None),
+                b'\x0ac': (None, b'C' * 33),
+            },
+        ),
+    ),
+)
+def test_hexary_diff(items1, items2, expected_key_diffs):
+    db1 = {}
+    trie1 = HexaryTrie(db1)
+    db2 = {}
+    trie2 = HexaryTrie(db2)
+    for key, val in items1:
+        trie1[key] = val
+    for key, val in items2:
+        trie2[key] = val
+
+    key_diffs = HexaryTrie.diff(trie1, trie2)
+    assert key_diffs == expected_key_diffs
+
+    logger1db = KeyAccessLogger(db1)
+    logger1 = HexaryTrie(logger1db, trie1.root_hash)
+    logger2db = KeyAccessLogger(db2)
+    logger2 = HexaryTrie(logger2db, trie2.root_hash)
+    for key, (val1, val2) in key_diffs.items():
+        # trigger reads to the relavant (diffed) keys
+        logger1[key]
+        logger2[key]
+
+    proof_only_db1 = {key: db1[key] for key in logger1db.read_keys}
+    proof_only_db2 = {key: db2[key] for key in logger2db.read_keys}
+
+    # make sure you don't get KeyErrors when creating the same diff from only the proof:
+    proof_only_trie1 = HexaryTrie(proof_only_db1, trie1.root_hash)
+    proof_only_trie2 = HexaryTrie(proof_only_db2, trie2.root_hash)
+    proof_only_diff = HexaryTrie.diff(proof_only_trie1, proof_only_trie2)
+    # also make sure you get the same diff
+    assert proof_only_diff == key_diffs
+
+'''
+        (
+            [(b'aa', b'A' * 33)],
+            [(b'aa', b'A' * 33), (b'ab', b'B' * 33)],
+            {b'ab': (None, b'B' * 33)},
+        ),
+        '''

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -19,6 +19,9 @@ from trie.exceptions import (
     MissingTrieNode,
     ValidationError,
 )
+from trie.utils.db import (
+    KeyAccessLogger,
+)
 from trie.utils.nodes import (
     decode_node,
 )
@@ -151,20 +154,6 @@ def test_trie_using_fixtures(name, updates, expected, deleted, final_root):
     for invalid_proof_key in deleted:
         with pytest.raises(KeyError):
             trie.get_proof(invalid_proof_key)
-
-
-class KeyAccessLogger(dict):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.read_keys = set()
-
-    def __getitem__(self, key):
-        result = super().__getitem__(key)
-        self.read_keys.add(key)
-        return result
-
-    def unread_keys(self):
-        return self.keys() - self.read_keys
 
 
 def test_hexary_trie_saves_each_root():

--- a/trie/utils/db.py
+++ b/trie/utils/db.py
@@ -1,6 +1,20 @@
 import contextlib
 
 
+class KeyAccessLogger(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.read_keys = set()
+
+    def __getitem__(self, key):
+        result = super().__getitem__(key)
+        self.read_keys.add(key)
+        return result
+
+    def unread_keys(self):
+        return self.keys() - self.read_keys
+
+
 class ScratchDB:
     """
     A wrapper of basic DB objects with uncommitted DB changes stored in local cache,

--- a/trie/utils/nodes.py
+++ b/trie/utils/nodes.py
@@ -47,7 +47,7 @@ def get_node_type(node):
     elif len(node) == 17:
         return NODE_TYPE_BRANCH
     else:
-        raise InvalidNode("Unable to determine node type")
+        raise InvalidNode("Unable to determine node type: %r" % node)
 
 
 def is_blank_node(node):


### PR DESCRIPTION
### What was wrong?

No convenient way to generate a trie diff without iterating all keys.

### How was it fixed?

This is suuuper WIP. It was really just a "scratch my own itch" thing while I was debugging the difference between two different state roots.

I'd say it's only ~1/4 implemented, and probably isn't the final API I would choose. But, it was already handy, definitely saved me time working on the state root. I was able to run it on a real state root on a real mainnet block (both account and storage state) to get meaningful results. There's probably a better approach, I didn't spend any time cleaning it up or looking for obvious dedup opportunities.

So this is a reminder to myself to come back to it when I'm not driving so hard on trinity mainnet support. Also, in case anyone else wants to crib the code, or pick it up where I left off...

Tangent: it's might be way simpler to use the `KeyAccessLogger` to generate the required proofs than the current method. (in `get_proof()`). Seems worth checking out.

#### Cute Animal Picture

![Cute animal picture]()
