### PR TITLE
squash_changes() bugfixes, when missing trie nodes

### DIFF
--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -541,7 +541,13 @@ class HexaryTrie:
         with scratch_db.batch_commit(do_deletes=self.is_pruning):
             memory_trie = type(self)(scratch_db, self.root_hash, prune=True)
             yield memory_trie
-        self.root_node = memory_trie.root_node
+        try:
+            self.root_node = memory_trie.root_node
+        except MissingTrieNode:
+            # if the new root node is missing,
+            #   (or no changes happened in a squash trie where the old root node was missing),
+            #   then we shouldn't crash here
+            self.root_hash = memory_trie.root_hash
 
     @contextlib.contextmanager
     def at_root(self, at_root_hash):


### PR DESCRIPTION
### What was wrong?

`squash_changes()` was not tested for cases when underlying nodes were missing (like in a trinity beam sync).

There were a couple issues:
- It would return `None` instead of raise a `KeyError` if the underlying was missing
- If the root of the original trie was missing, and an exception was raised, then it would throw a second exception when trying to revert to the original root

### How was it fixed?

Added some tests to cover the various scenarios
Updated `ScratchDB` to handle the new cases (which is starting to look suspiciously like `BatchDB` -- at some point we should probably extract that out of py-evm to use here and elsewhere)

I also added a couple more tests that were already passing, just wanted to avoid regressions.

#### Cute Animal Picture

![Cute animal picture](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQKeUU-8m6vFU_jzUwV_LDd8_BdCgOa5ZNjZgPv0zjbndQKcE4UCQ)