### PR TITLE
Implemented key absence proof

### DIFF
--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -148,9 +148,8 @@ def test_trie_using_fixtures(name, updates, expected, deleted, final_root):
     for valid_proof_key in expected:
         assert_proof(trie, valid_proof_key)
 
-    for invalid_proof_key in deleted:
-        with pytest.raises(KeyError):
-            trie.get_proof(invalid_proof_key)
+    for absence_proof_key in deleted:
+        assert_proof(trie, absence_proof_key)
 
 
 class KeyAccessLogger(dict):

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -110,7 +110,6 @@ def trim_long_bytes(param):
 
 def assert_proof(trie, key):
     proof = trie.get_proof(key)
-    assert len(proof) > 0
 
     proof_value = HexaryTrie.get_from_proof(trie.root_hash, key, proof)
     assert proof_value == trie.get(key)

--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -3,6 +3,7 @@ import pytest
 from eth_hash.auto import (
     keccak,
 )
+from eth_utils import to_bytes
 
 from trie.hexary import HexaryTrie
 from trie.exceptions import BadTrieProof
@@ -16,6 +17,16 @@ def test_get_from_proof_key_exists():
 def test_get_from_proof_key_does_not_exist():
     from .sample_proof_key_does_not_exist import key, state_root, proof
     assert HexaryTrie.get_from_proof(state_root, key, proof) == b''
+
+
+def test_get_proof_key_does_not_exist():
+	trie = HexaryTrie({})
+	trie[b"hello"] = b"world"
+	trie[b"hi"] = b"there"
+	proof = trie.get_proof(b"hey")
+	
+	assert len(proof) > 0
+	assert HexaryTrie.get_from_proof(trie.root_hash, b"hey", proof) == b''
 
 
 def test_get_from_proof_invalid():

--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -3,7 +3,6 @@ import pytest
 from eth_hash.auto import (
     keccak,
 )
-from eth_utils import to_bytes
 
 from trie.hexary import HexaryTrie
 from trie.exceptions import BadTrieProof
@@ -20,13 +19,13 @@ def test_get_from_proof_key_does_not_exist():
 
 
 def test_get_proof_key_does_not_exist():
-	trie = HexaryTrie({})
-	trie[b"hello"] = b"world"
-	trie[b"hi"] = b"there"
-	proof = trie.get_proof(b"hey")
-	
-	assert len(proof) > 0
-	assert HexaryTrie.get_from_proof(trie.root_hash, b"hey", proof) == b''
+    trie = HexaryTrie({})
+    trie[b"hello"] = b"world"
+    trie[b"hi"] = b"there"
+    proof = trie.get_proof(b"hey")
+
+    assert len(proof) > 0
+    assert HexaryTrie.get_from_proof(trie.root_hash, b"hey", proof) == b''
 
 
 def test_get_from_proof_invalid():

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -182,6 +182,9 @@ class HexaryTrie:
         node = self.get_node(self.root_hash)
         trie_key = bytes_to_nibbles(key)
 
+        if node == BLANK_NODE:
+            return (node,)
+
         return self._get_proof(node, trie_key)
 
     @staticmethod

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -181,9 +181,6 @@ class HexaryTrie:
         node = self.get_node(self.root_hash)
         trie_key = bytes_to_nibbles(key)
 
-        if node == BLANK_NODE:
-            return (node,)
-
         return self._get_proof(node, trie_key)
 
     def _get_proof(self, node, trie_key, proven_len=0, last_proof=tuple()):

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -194,13 +194,9 @@ class HexaryTrie:
 
         node_type = get_node_type(node)
         if node_type == NODE_TYPE_BLANK:
-            raise self._missing_key_error(trie_key)
+            return last_proof
         elif node_type == NODE_TYPE_LEAF:
-            current_key = extract_key(node)
-            if current_key == unproven_key:
-                return updated_proof
-            else:
-                raise self._missing_key_error(trie_key)
+            return updated_proof
         elif node_type == NODE_TYPE_EXTENSION:
             current_key = extract_key(node)
             if key_starts_with(unproven_key, current_key):
@@ -208,7 +204,7 @@ class HexaryTrie:
                 new_proven_len = proven_len + len(current_key)
                 return self._get_proof(next_node, trie_key, new_proven_len, updated_proof)
             else:
-                raise self._missing_key_error(trie_key)
+                return updated_proof
         elif node_type == NODE_TYPE_BRANCH:
             if not unproven_key:
                 return updated_proof

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -33,7 +33,6 @@ from trie.utils.nibbles import (
     bytes_to_nibbles,
     decode_nibbles,
     encode_nibbles,
-    nibbles_to_bytes,
 )
 from trie.utils.nodes import (
     decode_node,

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -187,10 +187,6 @@ class HexaryTrie:
 
         return self._get_proof(node, trie_key)
 
-    @staticmethod
-    def _missing_key_error(key_nibbles):
-        raise KeyError("Key %s does not exist" % nibbles_to_bytes(key_nibbles))
-
     def _get_proof(self, node, trie_key, proven_len=0, last_proof=tuple()):
         updated_proof = last_proof + (node, )
         unproven_key = trie_key[proven_len:]


### PR DESCRIPTION
### What was wrong?

There was no way to obtain a proof of absence for a key in a HexaryTrie, although `get_from_proof` already deals correctly with absence proofs as shown in this test case:
https://github.com/ethereum/py-trie/blob/5e989eedd6ffd5c5d35d3ad1809817362e6ee181/tests/test_proof.py#L16-L18

Closes #88

### How was it fixed?

I modified the `get_proof` implementation making it never raise, but always returning the sufficient nodes to either prove a key has a specific value or is absent (= has an empty value).

The reason I implemented it this way, without any additional parameter, is because it's the job of `get_from_proof` to actually check the proof against the expected value (see this [comment](https://github.com/ethereum/py-trie/issues/88#issuecomment-483791493)).

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/14125973/56275804-b3bed380-6101-11e9-85d7-32803073d2b8.jpg)