### PR TITLE
Use reference counting to avoid over-pruning trie

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
 Unreleased
 ----------
 
-None
+- Pruning Bugfix: with duplicate values at multiple keys, pruning would sometimes incorrectly
+  prune out a node that was still required. This is fixed for fresh databases, and unfixable
+  for existing databases. (Prune is not designed for on-disk/existing DBs anyhow)
+  https://github.com/ethereum/py-trie/pull/93
 
 1.4.0
 ----------

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -263,6 +263,7 @@ def test_hexary_trie_batch_save_keeps_last_root_data():
 
     with trie.squash_changes() as memory_trie:
         memory_trie.set(b'what floats on water?', b'a duck')
+        verify_ref_count(memory_trie)
 
     assert trie[b'what floats on water?'] == b'a duck'
 
@@ -278,6 +279,7 @@ def test_hexary_trie_batch_save_drops_last_root_data_when_pruning():
 
     with trie.squash_changes() as memory_trie:
         memory_trie.set(b'what floats on water?', b'a duck')
+        verify_ref_count(memory_trie)
 
     assert trie[b'what floats on water?'] == b'a duck'
 
@@ -296,6 +298,7 @@ def test_squash_changes_can_still_access_underlying_deleted_data():
 
     with trie.squash_changes() as memory_trie:
         memory_trie.set(b'what floats on water?', b'a duck')
+        verify_ref_count(memory_trie)
 
         # change to a root hash that the memory trie doesn't have anymore
         memory_trie.root_hash
@@ -311,10 +314,12 @@ def test_squash_changes_raises_correct_error_on_new_deleted_data():
 
     with trie.squash_changes() as memory_trie:
         memory_trie.set(b'what floats on water?', b'a duck')
+        verify_ref_count(memory_trie)
         middle_root_hash = memory_trie.root_hash
 
         memory_trie.set(b'what floats on water?', b'ooooohh')
         memory_trie.root_hash
+        verify_ref_count(memory_trie)
 
         # change to a root hash that the memory trie doesn't have anymore
         memory_trie.root_hash = middle_root_hash

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -12,6 +12,7 @@ from eth_utils import (
     to_bytes,
 )
 import pytest
+import rlp
 
 from trie import HexaryTrie
 from trie.constants import BLANK_NODE_HASH
@@ -429,3 +430,69 @@ def test_hexary_trie_raises_on_pruning_snapshot():
     with pytest.raises(ValidationError):
         with trie.at_root(BLANK_NODE_HASH):
             pass
+
+
+def verify_ref_count(trie):
+    enumerated_ref_count = trie.regenerate_ref_count()
+
+    tracked_keys = set(trie.ref_count.keys())
+    enumerated_keys = set(enumerated_ref_count.keys())
+
+    # we shouldn't be able to find any keys via enumeration that are untracked
+    untracked_keys = enumerated_keys - tracked_keys
+    assert len(untracked_keys) == 0
+
+    # any tracked keys that aren't enumerated should have 0 references
+    # (maybe they were added and subsequently removed)
+    for unenumerated_key in tracked_keys - enumerated_keys:
+        assert trie.ref_count[unenumerated_key] == 0
+
+    # all keys that were found in enumeration and tracking should have the same reference count
+    for matching_key in tracked_keys & enumerated_keys:
+        actual_num = trie.ref_count[matching_key]
+        expected_num = enumerated_ref_count[matching_key]
+        assert actual_num == expected_num
+
+
+@pytest.mark.parametrize(
+    'name, updates, expected, deleted, final_root',
+    FIXTURES_PERMUTED,
+    ids=trim_long_bytes,
+)
+def test_hexary_trie_ref_count(name, updates, expected, deleted, final_root):
+    db = {}
+    trie = HexaryTrie(db=db)
+    with trie.squash_changes() as memory_trie:
+        for key, value in updates:
+            if value is None:
+                del memory_trie[key]
+            else:
+                memory_trie[key] = value
+
+            verify_ref_count(memory_trie)
+
+        for key in deleted:
+            del memory_trie[key]
+            verify_ref_count(memory_trie)
+
+
+def test_hexary_trie_avoid_over_pruning():
+    db = {}
+    trie = HexaryTrie(db, prune=True)
+
+    def _insert(trie, index, val):
+        index_key = rlp.encode(index, sedes=rlp.sedes.big_endian_int)
+        trie[index_key] = val
+        return index_key
+
+    inserted_keys = []
+    for index, val in enumerate([b'\0' * 32] * 129):
+        new_key = _insert(trie, index, val)
+        inserted_keys.append(new_key)
+
+        # poke the trie to make sure all nodes are still present
+        for key in inserted_keys:
+            # If there's a problem, this will raise a MissingTrieNode
+            trie.get(key)
+
+        verify_ref_count(trie)


### PR DESCRIPTION
### What was wrong?

Fixes #92 

There is an example of where the current pruner incorrectly removes a
necessary node hash, because it got duplicated. See the new test:
test_hexary_trie_avoid_over_pruning()

### How was it fixed?

Added an incremental reference counter, which only prunes nodes when the
number of usages drops to zero. It only works on fresh databases. With
existing databases, it would still delete required nodes.

Also, it skips an unnecessary database write, which would incorrectly
increment the reference counter.

#### Cute Animal Picture

![Cute animal picture](https://images.boredomfiles.com/wp-content/uploads/2015/04/08-cute-animals-hokkaido-japan.jpg)