### PR TITLE
Add TrieFog and cache to track which parts of trie have been walked

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,10 @@ Features
 - New TraversedPartialPath exception, raised when you try to navigate to a node, but end up
   part-way inside an extension node, or try to navigate into a leaf node.
   https://github.com/ethereum/py-trie/pull/102
+- New HexaryTrieFog to help track unexplored prefixes, when walking a trie. Serializeable to bytes.
+  New exceptions PerfectVisibility or FullDirectionalVisibility when no prefixes are unexplored.
+  New TrieFrontierCache to reduce duplicate database accesses on a full trie walk.
+  https://github.com/ethereum/py-trie/pull/95
 
 Bugfixes
 ~~~~~~~~
@@ -48,6 +52,12 @@ Bugfixes
 - Avoid reading root node when unnecessary during squash_changes(). This can be important when
   building a witness, if the witness is supposed to be empty. (for example, in storage tries)
   https://github.com/ethereum/py-trie/pull/101
+
+Misc
+~~~~
+
+- Type annotation cleanups & upgrades flake8/eth-utils
+  https://github.com/ethereum/py-trie/pull/95
 
 1.4.0
 ----------

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
 
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
-        "eth-utils>=1.3.0,<2.0.0",
+        "eth-utils>=1.6.1,<2.0.0",
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<2",
         "sortedcontainers>=2.1.0,<3",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
         "pycryptodome",
     ],
     'lint': [
-        "flake8==3.4.1",
+        "flake8==3.8.1",
     ],
     'dev': [
         "bumpversion>=0.5.3,<1",

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "eth-utils>=1.3.0,<2.0.0",
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<2",
+        "sortedcontainers>=2.1.0,<3",
         "typing-extensions==3.7.4.2",
     ],
     extras_require=extras_require,

--- a/tests/test_fog.py
+++ b/tests/test_fog.py
@@ -1,0 +1,260 @@
+from eth_utils import ValidationError
+from hypothesis import (
+    given,
+    strategies as st,
+)
+import pytest
+
+from trie.exceptions import (
+    FullDirectionalVisibility,
+    PerfectVisibility,
+)
+from trie.fog import HexaryTrieFog
+
+
+def test_trie_fog_completion():
+    fog = HexaryTrieFog()
+
+    # fog should start with *nothing* verified
+    assert not fog.is_complete
+
+    # completing the empty prefix should immediately mark it as complete
+    empty_prefix = ()
+    completed_fog = fog.explore(empty_prefix, ())
+    assert completed_fog.is_complete
+
+    # original fog should be untouched
+    assert not fog.is_complete
+
+
+def test_trie_fog_expand_before_complete():
+    fog = HexaryTrieFog()
+
+    empty_prefix = ()
+    branched = fog.explore(empty_prefix, ((1,), (5,)))
+    assert not branched.is_complete
+
+    # complete only one prefix
+    single_prefix = branched.explore((1,), ())
+    assert not single_prefix.is_complete
+
+    completed = single_prefix.explore((5,), ())
+    assert completed.is_complete
+
+
+def test_trie_fog_expand_before_mark_all_complete():
+    fog = HexaryTrieFog()
+
+    empty_prefix = ()
+    branched = fog.explore(empty_prefix, ((1,), (5,)))
+    assert not branched.is_complete
+
+    # complete all sub-segments at once
+    completed = branched.mark_all_complete(((1,), (5,)))
+    assert completed.is_complete
+
+
+def test_trie_fog_composition_equality():
+    fog = HexaryTrieFog()
+
+    empty_prefix = ()
+    single_exploration = fog.explore(empty_prefix, ((9, 9, 9), ))
+
+    half_explore = fog.explore(empty_prefix, ((9, ),))
+    full_explore = half_explore.explore((9, ), ((9, 9), ))
+
+    assert single_exploration == full_explore
+
+
+def test_trie_fog_immutability():
+    fog = HexaryTrieFog()
+
+    fog1 = fog.explore((), ((1, ), (2, )))
+
+    fog2 = fog1.explore((1, ), ((3, ), ))
+
+    assert fog.nearest_unknown(()) == ()
+    assert fog1.nearest_unknown(()) == (1,)
+    assert fog2.nearest_unknown(()) == (1, 3)
+
+    assert fog != fog1
+    assert fog1 != fog2
+    assert fog != fog2
+
+
+@pytest.mark.parametrize('sub_segments', (
+    [(1, 2), (1, 2, 3, 4)],
+    [(1, 2), (1, 2)],
+))
+def test_trie_fog_explore_invalid(sub_segments):
+    """
+    Cannot explore with a sub_segment that is a child of another sub_segment,
+    or a duplicate
+    """
+    fog = HexaryTrieFog()
+    with pytest.raises(ValidationError):
+        fog.explore((), sub_segments)
+
+
+def test_trie_fog_nearest_unknown():
+    fog = HexaryTrieFog()
+
+    empty_prefix = ()
+    assert fog.nearest_unknown((1, 2, 3)) == empty_prefix
+
+    branched = fog.explore(empty_prefix, ((1, 1), (5, 5)))
+
+    # Test shallower
+    assert branched.nearest_unknown((0,)) == (1, 1)
+    assert branched.nearest_unknown((1,)) == (1, 1)
+    assert branched.nearest_unknown((2,)) == (1, 1)
+    assert branched.nearest_unknown((4,)) == (5, 5)
+    assert branched.nearest_unknown((5,)) == (5, 5)
+    assert branched.nearest_unknown((6,)) == (5, 5)
+
+    # Test same level
+    assert branched.nearest_unknown((0, 9)) == (1, 1)
+    assert branched.nearest_unknown((1, 1)) == (1, 1)
+    assert branched.nearest_unknown((2, 1)) == (1, 1)
+    assert branched.nearest_unknown((3, 2)) == (1, 1)
+    assert branched.nearest_unknown((3, 3)) == (5, 5)
+    assert branched.nearest_unknown((4, 9)) == (5, 5)
+    assert branched.nearest_unknown((5, 5)) == (5, 5)
+    assert branched.nearest_unknown((6, 1)) == (5, 5)
+
+    # Test deeper
+    assert branched.nearest_unknown((0, 9, 9)) == (1, 1)
+    assert branched.nearest_unknown((1, 1, 0)) == (1, 1)
+    assert branched.nearest_unknown((2, 1, 1)) == (1, 1)
+    assert branched.nearest_unknown((4, 9, 9)) == (5, 5)
+    assert branched.nearest_unknown((5, 5, 0)) == (5, 5)
+    assert branched.nearest_unknown((6, 1, 1)) == (5, 5)
+
+
+def test_trie_fog_nearest_unknown_fully_explored():
+    fog = HexaryTrieFog()
+    empty_prefix = ()
+    fully_explored = fog.explore(empty_prefix, ())
+
+    with pytest.raises(PerfectVisibility):
+        fully_explored.nearest_unknown(())
+
+    with pytest.raises(PerfectVisibility):
+        fully_explored.nearest_unknown((0,))
+
+
+def test_trie_fog_nearest_right():
+    fog = HexaryTrieFog()
+
+    empty_prefix = ()
+    assert fog.nearest_right((1, 2, 3)) == empty_prefix
+
+    branched = fog.explore(empty_prefix, ((1, 1), (5, 5)))
+
+    # Test shallower
+    assert branched.nearest_right((0,)) == (1, 1)
+    assert branched.nearest_right((1,)) == (1, 1)
+    assert branched.nearest_right((2,)) == (5, 5)
+    assert branched.nearest_right((4,)) == (5, 5)
+    assert branched.nearest_right((5,)) == (5, 5)
+    with pytest.raises(FullDirectionalVisibility):
+        assert branched.nearest_right((6,))
+
+    # Test same level
+    assert branched.nearest_right((0, 9)) == (1, 1)
+    assert branched.nearest_right((1, 1)) == (1, 1)
+    assert branched.nearest_right((2, 1)) == (5, 5)
+    assert branched.nearest_right((3, 2)) == (5, 5)
+    assert branched.nearest_right((3, 3)) == (5, 5)
+    assert branched.nearest_right((4, 9)) == (5, 5)
+    assert branched.nearest_right((5, 5)) == (5, 5)
+    with pytest.raises(FullDirectionalVisibility):
+        assert branched.nearest_right((5, 6))
+    with pytest.raises(FullDirectionalVisibility):
+        assert branched.nearest_right((6, 1))
+
+    # Test deeper
+    assert branched.nearest_right((0, 9, 9)) == (1, 1)
+    assert branched.nearest_right((1, 1, 0)) == (1, 1)
+    assert branched.nearest_right((2, 1, 1)) == (5, 5)
+    assert branched.nearest_right((4, 9, 9)) == (5, 5)
+    assert branched.nearest_right((5, 5, 0)) == (5, 5)
+    assert branched.nearest_right((5, 5, 15)) == (5, 5)
+    with pytest.raises(FullDirectionalVisibility):
+        assert branched.nearest_right((6, 0, 0))
+
+
+def test_trie_fog_nearest_right_empty():
+    fog = HexaryTrieFog()
+    empty_prefix = ()
+    fully_explored = fog.explore(empty_prefix, ())
+
+    with pytest.raises(PerfectVisibility):
+        fully_explored.nearest_right(())
+
+    with pytest.raises(PerfectVisibility):
+        fully_explored.nearest_right((0,))
+
+
+@given(
+    st.lists(
+        st.tuples(
+            # next index to use to search for a prefix to expand
+            st.lists(
+                st.integers(min_value=0, max_value=0xf),
+                max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
+            ),
+            # sub_segments to use to lift the fog
+            st.one_of(
+                # branch node (or leaf node if size == 0)
+                st.lists(
+                    st.tuples(
+                        st.integers(min_value=0, max_value=0xf),
+                    ),
+                    max_size=16,
+                    unique=True,
+                ),
+                # or extension node
+                st.tuples(
+                    st.lists(
+                        st.integers(min_value=0, max_value=0xf),
+                        min_size=2,
+                    ),
+                ),
+            ),
+        ),
+    ),
+)
+def test_trie_fog_serialize(expand_points):
+    """
+    Build a bunch of random trie fogs, serialize them to a bytes representation,
+    then deserialize them back.
+
+    Validate that all deserialized tries are equal to their starting tries and
+    respond to nearest_unknown the same as the original.
+    """
+    starting_fog = HexaryTrieFog()
+    for next_index, children in expand_points:
+        try:
+            next_unknown = starting_fog.nearest_unknown(next_index)
+        except PerfectVisibility:
+            # Have already completely explored the trie
+            break
+
+        starting_fog = starting_fog.explore(next_unknown, children)
+
+    if expand_points:
+        assert starting_fog != HexaryTrieFog()
+    else:
+        assert starting_fog == HexaryTrieFog()
+
+    resumed_fog = HexaryTrieFog.deserialize(starting_fog.serialize())
+    assert resumed_fog == starting_fog
+
+    if starting_fog.is_complete:
+        assert resumed_fog.is_complete
+    else:
+        for search_index, _ in expand_points:
+            nearest_unknown_original = starting_fog.nearest_unknown(search_index)
+            nearest_unknown_deserialized = resumed_fog.nearest_unknown(search_index)
+            assert nearest_unknown_deserialized == nearest_unknown_original

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -1,0 +1,506 @@
+from hypothesis import (
+    example,
+    given,
+    settings,
+    strategies as st,
+)
+
+from trie import HexaryTrie
+from trie.exceptions import (
+    TraversedPartialPath,
+    MissingTraversalNode,
+    MissingTrieNode,
+    PerfectVisibility,
+)
+from trie.fog import HexaryTrieFog, TrieFrontierCache
+from trie.iter import NodeIterator
+from trie.typing import Nibbles
+
+
+def _make_trie(keys):
+    """
+    Make a new HexaryTrie, insert all the given keys, with the value equal to the key.
+    Return the raw database and the HexaryTrie.
+    """
+    # Create trie
+    node_db = {}
+    trie = HexaryTrie(node_db)
+    with trie.squash_changes() as trie_batch:
+        for k in keys:
+            trie_batch[k] = k
+
+    return node_db, trie
+
+
+def _all_keys(trie):
+    """
+    Iterate through all keys in a trie
+    """
+    # TODO: delete me after NodeIterator.all() is added
+    iterator = NodeIterator(trie)
+    key = iterator.next(b'')
+    while key is not None:
+        yield key
+        key = iterator.next(key)
+
+
+@given(
+    st.lists(
+        st.binary(min_size=3, max_size=3),
+        unique=True,
+        max_size=1024,
+    ),
+    st.lists(
+        st.integers(min_value=0, max_value=0xf),
+        max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
+    ),
+)
+@settings(max_examples=300)
+def test_trie_walk_backfilling(trie_keys, index_nibbles):
+    """
+    - Create a random trie of 3-byte keys
+    - Drop all node bodies from the trie
+    - Use fog to index into random parts of the trie
+    - Every time a node is missing from the DB, replace it and retry
+    - Repeat until full trie has been explored with the HexaryTrieFog
+    """
+    node_db, trie = _make_trie(trie_keys)
+    index_key = Nibbles(index_nibbles)
+
+    # delete all nodes
+    dropped_nodes = dict(node_db)
+    node_db.clear()
+
+    # Core of the test: use the fog to convince yourself that you've traversed the entire trie
+    fog = HexaryTrieFog()
+    for _ in range(100000):
+        # Look up the next prefix to explore
+        try:
+            nearest_key = fog.nearest_unknown(index_key)
+        except PerfectVisibility:
+            # Test Complete!
+            break
+
+        # Try to navigate to the prefix, catching any errors about nodes missing from the DB
+        try:
+            node = trie.traverse(nearest_key)
+        except MissingTraversalNode as exc:
+            # Node was missing, so fill in the node and try again
+            node_db[exc.missing_node_hash] = dropped_nodes.pop(exc.missing_node_hash)
+            continue
+        else:
+            # Node was found, use the found node to "lift the fog" down to its longer prefixes
+            fog = fog.explore(nearest_key, node.sub_segments)
+    else:
+        assert False, "Must finish iterating the trie within ~100k runs"
+
+    # Make sure we removed all the dropped nodes to push them back to the trie db
+    assert len(dropped_nodes) == 0
+    # Make sure the fog agrees that it's completed
+    assert fog.is_complete
+    # Make sure we can walk the whole trie without any missing nodes
+    found_keys = set(_all_keys(trie))
+    # Make sure we found all the keys
+    assert found_keys == set(trie_keys)
+
+
+@given(
+    st.lists(
+        st.binary(min_size=3, max_size=3),
+        unique=True,
+        max_size=1024,
+    ),
+    st.lists(
+        st.integers(min_value=0, max_value=0xf),
+        max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
+    ),
+)
+@settings(max_examples=200)
+def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
+    """
+    Like test_trie_walk_backfilling but using the HexaryTrie.traverse_from API
+    """
+    node_db, trie = _make_trie(trie_keys)
+    index_key = Nibbles(index_nibbles)
+
+    # delete all nodes
+    dropped_nodes = dict(node_db)
+    node_db.clear()
+
+    # traverse_from() cannot traverse to the root node, so resolve that manually
+    try:
+        root = trie.root_node
+    except MissingTraversalNode as exc:
+        node_db[exc.missing_node_hash] = dropped_nodes.pop(exc.missing_node_hash)
+        root = trie.root_node
+
+    # Core of the test: use the fog to convince yourself that you've traversed the entire trie
+    fog = HexaryTrieFog()
+    for _ in range(100000):
+        # Look up the next prefix to explore
+        try:
+            nearest_key = fog.nearest_unknown(index_key)
+        except PerfectVisibility:
+            # Test Complete!
+            break
+
+        # Try to navigate to the prefix, catching any errors about nodes missing from the DB
+        try:
+            node = trie.traverse_from(root, nearest_key)
+        except MissingTraversalNode as exc:
+            # Node was missing, so fill in the node and try again
+            node_db[exc.missing_node_hash] = dropped_nodes.pop(exc.missing_node_hash)
+            continue
+        else:
+            # Node was found, use the found node to "lift the fog" down to its longer prefixes
+            fog = fog.explore(nearest_key, node.sub_segments)
+    else:
+        assert False, "Must finish iterating the trie within ~100k runs"
+
+    # Make sure we removed all the dropped nodes to push them back to the trie db
+    assert len(dropped_nodes) == 0
+    # Make sure the fog agrees that it's completed
+    assert fog.is_complete
+    # Make sure we can walk the whole trie without any missing nodes
+    found_keys = set(_all_keys(trie))
+    # Make sure we found all the keys
+    assert found_keys == set(trie_keys)
+
+
+@given(
+    # starting trie keys
+    st.lists(
+        st.binary(min_size=3, max_size=3),
+        unique=True,
+        min_size=1,
+        max_size=1024,
+    ),
+    # how many fog expansions to try before modifying the trie
+    st.integers(min_value=0, max_value=10000),
+    # all trie changes to make before the second trie walk
+    st.lists(
+        # one change, might be a...
+        st.one_of(
+            # insert
+            st.binary(min_size=3, max_size=3),
+            # update
+            st.tuples(
+                # index into existing key
+                st.integers(min_value=1, max_value=1024),
+                st.binary(min_size=1, max_size=128),
+            ),
+            # delete
+            st.tuples(
+                # index into existing key
+                st.integers(min_value=1, max_value=1024),
+                st.none(),
+            ),
+        ),
+    ),
+    # where to look for missing nodes in the first trie walk
+    st.lists(
+        st.integers(min_value=0, max_value=0xf),
+        max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
+    ),
+    # where to look for missing nodes in the second trie walk
+    st.lists(
+        st.integers(min_value=0, max_value=0xf),
+        max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
+    ),
+)
+@settings(max_examples=200)
+@example(
+    trie_keys=[
+        b'\x00\x00\x00',
+        b'\x01\x00\x00',
+        b'\x01\x00\x01',
+        b'\x10\x00\x00',
+    ],
+    number_explorations=212,
+    trie_changes=[(1, b'\x00\x00\x00\x00\x00\x00\x00'), (4, None)],
+    index_nibbles=[],
+    index_nibbles2=[],
+)
+def test_trie_walk_root_change_with_traverse(
+        trie_keys,
+        number_explorations,
+        trie_changes,
+        index_nibbles,
+        index_nibbles2,
+):
+    """
+    Like test_trie_walk_backfilling, but:
+    - Halt the trie walk early
+    - Modify the trie according to parameter trie_changes
+    - Continue walking the trie using the same HexaryTrieFog, until completion
+    - Verify that all required database values were replaced (where only the nodes under
+        the NEW trie root are required)
+    """
+    node_db, trie = _make_trie(trie_keys)
+
+    number_explorations %= len(node_db)
+
+    # delete all nodes
+    missing_nodes = dict(node_db)
+    node_db.clear()
+
+    # First walk
+    index_key = tuple(index_nibbles)
+    fog = HexaryTrieFog()
+    for _ in range(number_explorations):
+        # Look up the next prefix to explore
+        try:
+            nearest_key = fog.nearest_unknown(index_key)
+        except PerfectVisibility:
+            assert False, "Number explorations should be lower than database size, shouldn't finish"
+
+        # Try to navigate to the prefix, catching any errors about nodes missing from the DB
+        try:
+            node = trie.traverse(nearest_key)
+            # Note that a TraversedPartialPath should not happen here, because no trie changes
+            #   have happened, so we should have a perfect picture of the trie
+        except MissingTraversalNode as exc:
+            # Node was missing, so fill in the node and try again
+            node_db[exc.missing_node_hash] = missing_nodes.pop(exc.missing_node_hash)
+            continue
+        else:
+            # Node was found, use the found node to "lift the fog" down to its longer prefixes
+            fog = fog.explore(nearest_key, node.sub_segments)
+
+    # Modify Trie mid-walk, keeping track of the expected list of final keys
+    expected_final_keys = set(trie_keys)
+    with trie.squash_changes() as trie_batch:
+        for change in trie_changes:
+            # repeat until change is complete
+            change_complete = False
+            while not change_complete:
+                # Catch any missing nodes during trie change, and fix them up.
+                # This is equivalent to Trinity's "Beam Sync".
+                try:
+                    if isinstance(change, bytes):
+                        # insert!
+                        trie_batch[change] = change
+                        expected_final_keys.add(change)
+                    else:
+                        key_index, new_value = change
+                        key = trie_keys[key_index % len(trie_keys)]
+                        if new_value is None:
+                            del trie_batch[key]
+                            expected_final_keys.discard(key)
+                        else:
+                            # update (though may be an insert, if there was a previous delete)
+                            trie_batch[key] = new_value
+                            expected_final_keys.add(key)
+                except MissingTrieNode as exc:
+                    node_db[exc.missing_node_hash] = missing_nodes.pop(exc.missing_node_hash)
+                else:
+                    change_complete = True
+
+    # Second walk
+    index_key2 = tuple(index_nibbles2)
+
+    for _ in range(100000):
+        try:
+            nearest_key = fog.nearest_unknown(index_key2)
+        except PerfectVisibility:
+            # Complete!
+            break
+
+        try:
+            node = trie.traverse(nearest_key)
+            sub_segments = node.sub_segments
+        except MissingTraversalNode as exc:
+            node_db[exc.missing_node_hash] = missing_nodes.pop(exc.missing_node_hash)
+            continue
+        except TraversedPartialPath as exc:
+            # You might only get part-way down a path of nibbles if your fog is based on an old trie
+            # Determine the new sub-segments that are accessible from this partial traversal
+            sub_segments = [
+                exc.nibbles_traversed + next_segment
+                for next_segment in exc.node.sub_segments
+            ]
+
+        # explore the fog if there were no exceptions, or if you traversed a partial path
+        fog = fog.explore(nearest_key, sub_segments)
+    else:
+        assert False, "Must finish iterating the trie within ~100k runs"
+
+    # Final assertions
+    assert fog.is_complete
+    # We do *not* know that we have replaced all the missing_nodes, because of the trie changes
+
+    # Make sure we can walk the whole trie without any missing nodes
+    found_keys = set(_all_keys(trie))
+    assert found_keys == expected_final_keys
+
+
+@given(
+    # starting trie keys
+    st.lists(
+        st.binary(min_size=3, max_size=3),
+        unique=True,
+        min_size=1,
+        max_size=1024,
+    ),
+    # how many fog expansions to try before modifying the trie
+    st.integers(min_value=0, max_value=10000),
+    # all trie changes to make before the second trie walk
+    st.lists(
+        # one change, might be a...
+        st.one_of(
+            # insert
+            st.binary(min_size=3, max_size=3),
+            # update
+            st.tuples(
+                # index into existing key
+                st.integers(min_value=1, max_value=1024),
+                st.binary(min_size=1, max_size=128),
+            ),
+            # delete
+            st.tuples(
+                # index into existing key
+                st.integers(min_value=1, max_value=1024),
+                st.none(),
+            ),
+        ),
+    ),
+    # where to look for missing nodes in the first trie walk
+    st.lists(
+        st.integers(min_value=0, max_value=0xf),
+        max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
+    ),
+    # where to look for missing nodes in the second trie walk
+    st.lists(
+        st.integers(min_value=0, max_value=0xf),
+        max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
+    ),
+)
+@settings(max_examples=200)
+def test_trie_walk_root_change_with_cached_traverse_from(
+        trie_keys,
+        number_explorations,
+        trie_changes,
+        index_nibbles,
+        index_nibbles2,
+):
+    """
+    Like test_trie_walk_root_change_with_traverse but using HexaryTrie.traverse_from
+    when possible.
+    """
+    node_db, trie = _make_trie(trie_keys)
+
+    number_explorations %= len(node_db)
+    cache = TrieFrontierCache()
+
+    # delete all nodes
+    missing_nodes = dict(node_db)
+    node_db.clear()
+
+    # First walk
+    index_key = tuple(index_nibbles)
+    fog = HexaryTrieFog()
+    for _ in range(number_explorations):
+        try:
+            nearest_prefix = fog.nearest_unknown(index_key)
+        except PerfectVisibility:
+            assert False, "Number explorations should be lower than database size, shouldn't finish"
+
+        try:
+            # Use the cache, if possible, to look up the parent node of nearest_prefix
+            try:
+                cached_node, uncached_key = cache.get(nearest_prefix)
+            except KeyError:
+                # Must navigate from the root. In this 1st walk, only the root should not be cached
+                assert nearest_prefix == ()
+                node = trie.traverse(nearest_prefix)
+            else:
+                # Only one database lookup required
+                node = trie.traverse_from(cached_node, uncached_key)
+
+            # Note that a TraversedPartialPath should not happen here, because no trie changes
+            #   have happened, so we should have a perfect picture of the trie
+        except MissingTraversalNode as exc:
+            # Each missing node should only need to be retrieve (at most) once
+            node_db[exc.missing_node_hash] = missing_nodes.pop(exc.missing_node_hash)
+            continue
+        else:
+            fog = fog.explore(nearest_prefix, node.sub_segments)
+
+            if node.sub_segments:
+                cache.add(nearest_prefix, node.raw, node.sub_segments)
+            else:
+                cache.delete(nearest_prefix)
+
+    # Modify Trie mid-walk, keeping track of the expected list of final keys
+    expected_final_keys = set(trie_keys)
+    with trie.squash_changes() as trie_batch:
+        for change in trie_changes:
+            # repeat until change is complete
+            change_complete = False
+            while not change_complete:
+                # Catch any missing nodes during trie change, and fix them up.
+                # This is equivalent to Trinity's "Beam Sync".
+                try:
+                    if isinstance(change, bytes):
+                        # insert!
+                        trie_batch[change] = change
+                        expected_final_keys.add(change)
+                    else:
+                        key_index, new_value = change
+                        key = trie_keys[key_index % len(trie_keys)]
+                        if new_value is None:
+                            del trie_batch[key]
+                            expected_final_keys.discard(key)
+                        else:
+                            # update (though may be an insert, if there was a previous delete)
+                            trie_batch[key] = new_value
+                            expected_final_keys.add(key)
+                except MissingTrieNode as exc:
+                    node_db[exc.missing_node_hash] = missing_nodes.pop(exc.missing_node_hash)
+                else:
+                    change_complete = True
+
+    # Second walk
+    index_key2 = tuple(index_nibbles2)
+
+    for _ in range(100000):
+        try:
+            nearest_prefix = fog.nearest_unknown(index_key2)
+        except PerfectVisibility:
+            # Complete!
+            break
+
+        try:
+            try:
+                cached_node, uncached_key = cache.get(nearest_prefix)
+            except KeyError:
+                node = trie.traverse(nearest_prefix)
+            else:
+                node = trie.traverse_from(cached_node, uncached_key)
+            sub_segments = node.sub_segments
+        except MissingTraversalNode as exc:
+            # Each missing node should only need to be retrieve (at most) once
+            node_db[exc.missing_node_hash] = missing_nodes.pop(exc.missing_node_hash)
+            continue
+        except TraversedPartialPath as exc:
+            sub_segments = [
+                exc.nibbles_traversed + segment
+                for segment in exc.node.sub_segments
+            ]
+
+        fog = fog.explore(nearest_prefix, sub_segments)
+
+        if sub_segments:
+            cache.add(nearest_prefix, node.raw, sub_segments)
+        else:
+            cache.delete(nearest_prefix)
+    else:
+        assert False, "Must finish iterating the trie within ~100k runs"
+
+    # Final assertions
+    assert fog.is_complete
+    # We do *not* know that we have replaced all the missing_nodes, because of the trie changes
+
+    # Make sure we can walk the whole trie without any missing nodes
+    found_keys = set(_all_keys(trie))
+    assert found_keys == expected_final_keys

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,3 +1,8 @@
+from hypothesis import (
+    example,
+    given,
+    strategies as st,
+)
 import pytest
 
 from trie.typing import (
@@ -37,3 +42,29 @@ def test_valid_nibbles(valid_nibbles):
 def test_invalid_nibbles(invalid_nibbles, exception):
     with pytest.raises(exception):
         Nibbles(invalid_nibbles)
+
+
+@given(st.lists(st.integers(min_value=0, max_value=0xf)), st.booleans())
+@example([0], True)
+def test_nibbles_repr(nibbles_input, as_ipython):
+    nibbles = Nibbles(nibbles_input)
+
+    if as_ipython:
+
+        class FakePrinter:
+            str_buffer = ''
+
+            def text(self, new_text):
+                self.str_buffer += new_text
+
+        p = FakePrinter()
+        nibbles._repr_pretty_(p, cycle=False)
+        repr_string = p.str_buffer
+    else:
+        repr_string = repr(nibbles)
+
+    evaluated_repr = eval(repr_string)
+    assert evaluated_repr == tuple(nibbles_input)
+
+    re_cast = Nibbles(evaluated_repr)
+    assert re_cast == nibbles

--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -1,9 +1,13 @@
 from typing import Optional
 
+from eth_typing import (
+    Hash32,
+)
 from hexbytes import HexBytes
 
 from trie.typing import (
     Nibbles,
+    NibblesInput,
     HexaryTrieNode,
 )
 
@@ -46,8 +50,8 @@ class MissingTrieNode(Exception):
     """
     def __init__(
             self,
-            missing_node_hash: 'Hash32',
-            root_hash: 'Hash32',
+            missing_node_hash: Hash32,
+            root_hash: Hash32,
             requested_key: bytes,
             prefix: Nibbles = None,
             *args):
@@ -60,7 +64,7 @@ class MissingTrieNode(Exception):
             raise TypeError("Requested key must be bytes, was: %r" % requested_key)
 
         if prefix is not None:
-            prefix_nibbles = Nibbles(prefix)
+            prefix_nibbles: Optional[Nibbles] = Nibbles(prefix)
         else:
             prefix_nibbles = None
 
@@ -74,8 +78,8 @@ class MissingTrieNode(Exception):
 
     def __repr__(self) -> str:
         return (
-            f"MissingTrieNode({self.missing_node_hash}, {self.root_hash}, "
-            f"{self.requested_key}, prefix={self.prefix})"
+            f"MissingTrieNode({self.missing_node_hash!r}, {self.root_hash!r}, "
+            f"{self.requested_key!r}, prefix={self.prefix!r})"
         )
 
     def __str__(self) -> str:
@@ -117,14 +121,14 @@ class MissingTraversalNode(Exception):
         - traverse_from() ignore's the trie's root, so the root hash is unknown
         - the requested_key and prefix are unavailable because only the suffix of the key is known
     """
-    def __init__(self, missing_node_hash: 'Hash32', nibbles_traversed: Nibbles, *args) -> None:
+    def __init__(self, missing_node_hash: Hash32, nibbles_traversed: NibblesInput, *args) -> None:
         if not isinstance(missing_node_hash, bytes):
             raise TypeError("Missing node hash must be bytes, was: %r" % missing_node_hash)
 
         super().__init__(HexBytes(missing_node_hash), Nibbles(nibbles_traversed), *args)
 
     def __repr__(self) -> str:
-        return f"MissingTraversalNode({self.missing_node_hash}, {self.nibbles_traversed})"
+        return f"MissingTraversalNode({self.missing_node_hash!r}, {self.nibbles_traversed!r})"
 
     def __str__(self) -> str:
         return (
@@ -149,8 +153,7 @@ class TraversedPartialPath(Exception):
     Raised when a traversal key ends in the middle of a partial path. It might be in
     an extension node or a leaf node.
     """
-    def __init__(self, nibbles_traversed: Nibbles, node: HexaryTrieNode, *args) -> None:
-        # TODO drop Nibbles() cast when type checking is turned on
+    def __init__(self, nibbles_traversed: NibblesInput, node: HexaryTrieNode, *args) -> None:
         super().__init__(Nibbles(nibbles_traversed), node, *args)
 
     def __repr__(self) -> str:

--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -173,3 +173,21 @@ class TraversedPartialPath(Exception):
         where traversal went part-way into the path. It must not be a branch node.
         """
         return self.args[1]
+
+
+class PerfectVisibility(Exception):
+    """
+    Raised when calling :class:`trie.fog.HexaryTrieFog` methods that look for unknown prefixes,
+    like :meth:`~trie.fog.HexaryTrieFog.nearest_unknown`, and there are no unknown parts of
+    the trie. (in other words the fog reports :meth:`~trie.fog.HexaryTrieFog.is_complete` as True.
+    """
+    pass
+
+
+class FullDirectionalVisibility(Exception):
+    """
+    Raised when calling :meth:`trie.fog.HexaryTrieFog.nearest_right`, and there are no unknown
+    prefixes *in that direction* of the trie. (The fog may not report
+    :meth:`~trie.fog.HexaryTrieFog.is_complete` as True, because more may be available to the left).
+    """
+    pass

--- a/trie/fog.py
+++ b/trie/fog.py
@@ -306,7 +306,7 @@ class TrieFrontierCache:
 
         # add cache entry for each child
         for segment in sub_segments:
-            new_prefix = node_prefix + segment
+            new_prefix = node_prefix + Nibbles(segment)
             self._cache[new_prefix] = (trie_node, Nibbles(segment))
 
     def delete(self, prefix: NibblesInput) -> None:

--- a/trie/fog.py
+++ b/trie/fog.py
@@ -128,7 +128,7 @@ class HexaryTrieFog:
             new_unexplored_prefixes.remove(prefix)
         return self._new_trie_fog(new_unexplored_prefixes)
 
-    def nearest_unknown(self, key_input: NibblesInput) -> Nibbles:
+    def nearest_unknown(self, key_input: NibblesInput = ()) -> Nibbles:
         """
         Find the foggy prefix that is nearest to the supplied key.
 

--- a/trie/fog.py
+++ b/trie/fog.py
@@ -1,0 +1,314 @@
+import ast
+from itertools import zip_longest
+from typing import (
+    Any,
+    Sequence,
+    Tuple,
+)
+
+from eth_utils import (
+    to_tuple,
+    ValidationError,
+)
+from sortedcontainers import SortedSet
+
+from trie.exceptions import (
+    FullDirectionalVisibility,
+    PerfectVisibility,
+)
+from trie.typing import (
+    Nibbles,
+    NibblesInput,
+    RawHexaryNode,
+)
+from trie.utils.nibbles import (
+    decode_nibbles,
+    encode_nibbles,
+)
+from trie.utils.nodes import (
+    key_starts_with,
+)
+
+
+class HexaryTrieFog:
+    """
+    Keeps track of which parts of a trie have been verified to exist.
+
+    Named after "fog of war" popular in video games like... Red Alert? IDK, I'm old.
+
+    Object is immutable. Any changes, like marking a key prefix as complete, will
+    return a new HexaryTrieFog object.
+    """
+    _unexplored_prefixes: SortedSet
+
+    # INVARIANT: No unexplored prefix may start with another unexplored prefix
+    #   For example, _unexplored_prefixes may not be {(1, 2), (1, 2, 3)}.
+
+    def __init__(self) -> None:
+        # Always start without knowing anything about a trie. The only unexplored
+        #   prefix is the root prefix: (), which means the whole trie is unexplored.
+        self._unexplored_prefixes = SortedSet({()})
+
+    def __repr__(self) -> str:
+        return f"HexaryTrieFog<{self._unexplored_prefixes!r}>"
+
+    @property
+    def is_complete(self) -> bool:
+        return len(self._unexplored_prefixes) == 0
+
+    def explore(
+            self,
+            old_prefix_input: NibblesInput,
+            foggy_sub_segments: Sequence[NibblesInput]) -> 'HexaryTrieFog':
+        """
+        The fog lifts from the old prefix. This call returns a HexaryTrieFog that narrows
+        down the unexplored key prefixes. from the old prefix to the indicated children.
+
+        For example, if only the key prefix 0x12 is unexplored, then calling
+        explore((1, 2), ((3,), (0xe, 0xf))) would mark large swaths of 0x12 explored, leaving only
+        two prefixes as unknown: 0x123 and 0x12ef. To continue exploring those prefixes, navigate
+        to them using traverse() or traverse_from().
+
+        The sub_segments_input may be empty, which means the old prefix has been fully explored.
+        """
+        old_prefix = Nibbles(old_prefix_input)
+        sub_segments = [Nibbles(segment) for segment in foggy_sub_segments]
+        new_fog_prefixes = self._unexplored_prefixes.copy()
+
+        try:
+            new_fog_prefixes.remove(old_prefix)
+        except KeyError:
+            raise ValidationError(f"Old parent {old_prefix} not found in {new_fog_prefixes!r}")
+
+        if len(set(sub_segments)) != len(sub_segments):
+            raise ValidationError(
+                f"Got duplicate sub_segments in {sub_segments} to HexaryTrieFog.explore()"
+            )
+
+        # Further validation that no segment is a prefix of another
+        all_lengths = set(len(segment) for segment in sub_segments)
+        if len(all_lengths) > 1:
+            # The known use case of exploring nodes one at a time will never arrive in this
+            #   validation check which might be slow. Leaf nodes have no sub segments,
+            #   extension nodes have exactly one, and branch nodes have all sub_segments
+            #   of length 1. If a new use case hits this verification, and speed becomes an issue,
+            #   see https://github.com/ethereum/py-trie/issues/107
+            for segment in sub_segments:
+                shorter_lengths = [length for length in all_lengths if length < len(segment)]
+                for check_length in shorter_lengths:
+                    trimmed_segment = segment[:check_length]
+                    if trimmed_segment in sub_segments:
+                        raise ValidationError(
+                            f"Cannot add {segment} which is a child of segment {trimmed_segment}"
+                        )
+
+        new_fog_prefixes.update([old_prefix + segment for segment in sub_segments])
+        return self._new_trie_fog(new_fog_prefixes)
+
+    def mark_all_complete(self, prefixes: Sequence[NibblesInput]) -> 'HexaryTrieFog':
+        """
+        These might be leaves, or prefixes with 0 unknown keys within the range.
+
+        This is equivalent to the following, but with better performance:
+
+            result_fog = old_fog
+            for complete_prefix in prefixes:
+                result_fog = result_fog.explore(complete_prefix, ())
+        """
+        new_unexplored_prefixes = self._unexplored_prefixes.copy()
+        for prefix in prefixes:
+            if prefix not in new_unexplored_prefixes:
+                raise ValidationError(
+                    f"When marking {prefix} complete, could not find in {new_unexplored_prefixes!r}"
+                )
+
+            new_unexplored_prefixes.remove(prefix)
+        return self._new_trie_fog(new_unexplored_prefixes)
+
+    def nearest_unknown(self, key_input: NibblesInput) -> Nibbles:
+        """
+        Find the foggy prefix that is nearest to the supplied key.
+
+        If prefixes are exactly the same distance to the left and right,
+        then return the prefix on the right.
+
+        :raises PerfectVisibility: if there are no foggy prefixes remaining
+        """
+        key = Nibbles(key_input)
+
+        index = self._unexplored_prefixes.bisect(key)
+
+        if index == 0:
+            # If sorted set is empty, bisect will return 0
+            # But it might also return 0 if the search value is lower than the lowest existing
+            try:
+                return self._unexplored_prefixes[0]
+            except IndexError as exc:
+                raise PerfectVisibility("There are no more unexplored prefixes") from exc
+        elif index == len(self._unexplored_prefixes):
+            return self._unexplored_prefixes[-1]
+        else:
+            nearest_left = self._unexplored_prefixes[index - 1]
+            nearest_right = self._unexplored_prefixes[index]
+
+            # is the left or right unknown prefix closer?
+            left_distance = self._prefix_distance(nearest_left, key)
+            right_distance = self._prefix_distance(key, nearest_right)
+            if left_distance < right_distance:
+                return nearest_left
+            else:
+                return nearest_right
+
+    def nearest_right(self, key_input: NibblesInput) -> Nibbles:
+        """
+        Find the foggy prefix that is nearest on the right to the supplied key.
+
+        :raises PerfectVisibility: if there are no foggy prefixes to the right
+        """
+        key = Nibbles(key_input)
+
+        index = self._unexplored_prefixes.bisect(key)
+
+        if index == 0:
+            # If sorted set is empty, bisect will return 0
+            # But it might also return 0 if the search value is lower than the lowest existing
+            try:
+                return self._unexplored_prefixes[0]
+            except IndexError as exc:
+                raise PerfectVisibility("There are no more unexplored prefixes") from exc
+        else:
+            nearest_left = self._unexplored_prefixes[index - 1]
+
+            # always return nearest right, unless prefix of key is unexplored
+            if key_starts_with(key, nearest_left):
+                return nearest_left
+            else:
+                try:
+                    # This can raise a IndexError if index == len(unexplored prefixes)
+                    return self._unexplored_prefixes[index]
+                except IndexError as exc:
+                    raise FullDirectionalVisibility(
+                        f"There are no unexplored prefixes to the right of {key}"
+                    ) from exc
+
+    @staticmethod
+    @to_tuple
+    def _prefix_distance(low_key: Nibbles, high_key: Nibbles) -> Tuple[int, ...]:
+        """
+        How far are the two keys from each other, as a sequence of differences.
+        The first non-zero distance must be positive, but the remaining distances may
+        be negative. Distances are designed to be simply compared, like distance1 < distance2.
+
+        The high_key must be higher than the low key, or the output distances are not
+        guaranteed to be accurate.
+        """
+        for low_nibble, high_nibble in zip_longest(low_key, high_key, fillvalue=None):
+            if low_nibble is None:
+                final_low_nibble = 15
+            else:
+                final_low_nibble = low_nibble
+
+            if high_nibble is None:
+                final_high_nibble = 0
+            else:
+                final_high_nibble = high_nibble
+
+            # Note: this might return a negative value. It's fine, because only the
+            #   relative distance matters. For example (1, 2) and (2, 1) produce a
+            #   distance of (1, -1). If the other reference point is (3, 1), making
+            #   the distance to the middle (1, 0), then the "correct" thing happened.
+            #   The (1, 2) key is a tiny bit closer to the (2, 1) key, and a tuple
+            #   comparison of the distance will show it as a smaller distance.
+            yield final_high_nibble - final_low_nibble
+
+    @classmethod
+    def _new_trie_fog(cls, unexplored_prefixes: SortedSet) -> 'HexaryTrieFog':
+        """
+        Convert a set of unexplored prefixes to a proper HexaryTrieFog object.
+        """
+        copy = cls()
+        copy._unexplored_prefixes = unexplored_prefixes
+        return copy
+
+    def serialize(self) -> bytes:
+        # encode nibbles to a bytes value, to compress this down a bit
+        prefixes = [
+            encode_nibbles(nibbles)
+            for nibbles in self._unexplored_prefixes
+        ]
+        return f"HexaryTrieFog:{prefixes!r}".encode()
+
+    @classmethod
+    def deserialize(cls, encoded: bytes) -> 'HexaryTrieFog':
+        serial_prefix = b'HexaryTrieFog:'
+        if not encoded.startswith(serial_prefix):
+            raise ValueError(f"Cannot deserialize this into HexaryTrieFog object: {encoded}")
+        else:
+            encoded_list = encoded[len(serial_prefix):]
+            prefix_list = ast.literal_eval(encoded_list.decode())
+            deserialized_prefixes = SortedSet(
+                # decode nibbles from compressed bytes value, and validate each value in range(16)
+                Nibbles(decode_nibbles(prefix))
+                for prefix in prefix_list
+            )
+            return cls._new_trie_fog(deserialized_prefixes)
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, HexaryTrieFog):
+            return False
+        else:
+            return self._unexplored_prefixes == other._unexplored_prefixes
+
+
+class TrieFrontierCache:
+    """
+    Keep a cache of RawHexaryNode bodies for use with traverse_from. This
+    can be used neatly with HexaryTrieFog to only keep a cache of the frontier
+    of unexplored nodes, so that every expansion into a new unexplored node requires
+    only one database lookup instead of log(n).
+    """
+    def __init__(self) -> None:
+        self._cache = {}
+
+    def get(self, prefix: NibblesInput) -> Tuple[RawHexaryNode, Nibbles]:
+        """
+        Find the cached node body of the parent of the given prefix.
+
+        :return: parent node body, and the path from parent to the given prefix
+
+        :raises KeyError: if there is no cached value for the prefix
+        """
+        return self._cache[prefix]
+
+    def add(
+            self,
+            node_prefix: NibblesInput,
+            trie_node: RawHexaryNode,
+            sub_segments: Sequence[NibblesInput]) -> None:
+
+        """
+        Add a new cached node body for each of the sub segments supplied. Later cache
+        lookups will be in the form of get(node_prefix + sub_segments[0]).
+
+        :param node_prefix: the path from the root to the cached node
+        :param trie_node: the body to cache
+        :param sub_segments: all of the children of the parent which should be made indexable
+        """
+
+        # remove the cache entry for looking up node_prefix as a child
+        if node_prefix != ():
+            # If the cache entry doesn't exist, we can just ignore its absence
+            self._cache.pop(Nibbles(node_prefix), None)
+
+        # add cache entry for each child
+        for segment in sub_segments:
+            new_prefix = Nibbles(node_prefix + segment)
+            self._cache[new_prefix] = (trie_node, Nibbles(segment))
+
+    def delete(self, prefix: NibblesInput) -> None:
+        """
+        Delete the cache of the parent node for the given prefix. This only deletes
+        this prefix's reference to the parent node, not all references to the parent node.
+        """
+        # If the cache entry doesn't exist, we can just ignore its absence
+        self._cache.pop(Nibbles(prefix), None)

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -403,7 +403,7 @@ class HexaryTrie:
     def root_node(self):
         try:
             return self.get_node(self.root_hash)
-        except KeyError as exc:
+        except KeyError:
             raise MissingTraversalNode(self.root_hash, nibbles_traversed=())
 
     @root_node.setter

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -34,6 +34,7 @@ from trie.exceptions import (
 )
 from trie.typing import (
     Nibbles,
+    NibblesInput,
     HexaryTrieNode,
     RawHexaryNode,
 )
@@ -155,7 +156,7 @@ class HexaryTrie:
         else:
             raise Exception("Invariant: This shouldn't ever happen")
 
-    def traverse(self, trie_key_input: Nibbles) -> HexaryTrieNode:
+    def traverse(self, trie_key_input: NibblesInput) -> HexaryTrieNode:
         """
         Find the node at the path of nibbles provided. The most trivial example is
         to get the root node, using ``traverse(())``.
@@ -165,7 +166,6 @@ class HexaryTrie:
         :raises MissingTraversalNode: if a node body is missing from the database
         :raises TraversedPartialPath: if trie key extends part-way down an extension or leaf node
         """
-        # Since this value is supplied externally, re-verify nibble values by initializing again
         trie_key = Nibbles(trie_key_input)
 
         node, remaining_key = self._traverse(self.root_hash, trie_key)
@@ -227,7 +227,7 @@ class HexaryTrie:
             node_type = get_node_type(node)
 
             if node_type == NODE_TYPE_BLANK:
-                return BLANK_NODE, ()
+                return BLANK_NODE, Nibbles(())  # type: ignore # mypy thinks BLANK_NODE != b''
             elif node_type == NODE_TYPE_LEAF:
                 return node, remaining_key
             elif node_type == NODE_TYPE_EXTENSION:
@@ -250,7 +250,7 @@ class HexaryTrie:
                 raise MissingTraversalNode(exc.args[0], used_key)
 
         # navigated down the full key
-        return node, ()
+        return node, Nibbles(())
 
     def _traverse_extension(self, node, trie_key):
         current_key = extract_key(node)

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -2,6 +2,7 @@ import enum
 from typing import (
     List,
     NamedTuple,
+    Sequence,
     Tuple,
     Union,
 )
@@ -57,9 +58,15 @@ class Nibble(enum.IntEnum):
         return hex(self.value)
 
 
-class Nibbles(tuple):
-    def __new__(cls, nibbles):
-        if not is_list_like(nibbles):
+# A user-input value, where each element will be validated as a Nibble instead of int
+NibblesInput = Sequence[int]
+
+
+class Nibbles(Tuple[Nibble, ...]):
+    def __new__(cls, nibbles: NibblesInput) -> 'Nibbles':
+        if type(nibbles) is Nibbles:
+            return nibbles
+        elif not is_list_like(nibbles):
             raise TypeError(f"Must pass in a tuple of nibbles, but got {nibbles!r}")
         else:
             return tuple.__new__(cls, (Nibble(maybe_nibble) for maybe_nibble in nibbles))

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -68,13 +68,15 @@ NibblesInput = Sequence[int]
 class Nibbles(Tuple[Nibble, ...]):
     def __new__(cls, nibbles: NibblesInput) -> 'Nibbles':
         if type(nibbles) is Nibbles:
-            return nibbles
+            # instanceof thinks that a Tuple[Nibble, ...] *is* a Nibbles, so we use
+            #   a stricter type check here
+            return nibbles  # type: ignore  # mypy doesn't recognize that this is now a Nibbles
         elif not is_list_like(nibbles):
             raise TypeError(f"Must pass in a tuple of nibbles, but got {nibbles!r}")
         else:
             return tuple.__new__(cls, (Nibble(maybe_nibble) for maybe_nibble in nibbles))
 
-    def __add__(self, other: NibblesInput) -> 'Nibbles':
+    def __add__(self, other: Tuple[Nibble, ...]) -> 'Nibbles':
         return Nibbles(super().__add__(other))
 
 

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -79,6 +79,13 @@ class Nibbles(Tuple[Nibble, ...]):
     def __add__(self, other: Tuple[Nibble, ...]) -> 'Nibbles':
         return Nibbles(super().__add__(other))
 
+    def _repr_pretty_(self, p, cycle: bool) -> None:
+        # Weird, ipython seems to drop the trailing comma in the pretty repr they do. Fixing...
+        if cycle:
+            p.text('(...)')
+        else:
+            p.text(super().__repr__())
+
 
 class HexaryTrieNode(NamedTuple):
     """

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -1,13 +1,16 @@
 import enum
 from typing import (
+    Iterable,
     List,
     NamedTuple,
     Sequence,
     Tuple,
+    TypeVar,
     Union,
 )
 from typing_extensions import (
     Literal,
+    Protocol,
 )
 
 from eth_utils import (
@@ -71,6 +74,9 @@ class Nibbles(Tuple[Nibble, ...]):
         else:
             return tuple.__new__(cls, (Nibble(maybe_nibble) for maybe_nibble in nibbles))
 
+    def __add__(self, other: NibblesInput) -> 'Nibbles':
+        return Nibbles(super().__add__(other))
+
 
 class HexaryTrieNode(NamedTuple):
     """
@@ -105,3 +111,39 @@ class HexaryTrieNode(NamedTuple):
     The node body, which is useful for calls to HexaryTrie.traverse_from(...),
     for faster access of sub-nodes.
     """
+
+
+T = TypeVar('T')
+
+
+class GenericSortedSet(Protocol[T]):
+    """
+    A protocol definining the minimal subset of features used from
+    sortedcontainers.SortedSet. Feel free to add more as needed.
+    """
+    def __contains__(self, search_value: T) -> bool:
+        ...
+
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    def __len__(self) -> int:
+        ...
+
+    def __iter__(self) -> 'GenericSortedSet[T]':
+        ...
+
+    def __next__(self) -> T:
+        ...
+
+    def bisect(self, search_value: T) -> int:
+        ...
+
+    def copy(self) -> 'GenericSortedSet[T]':
+        ...
+
+    def remove(self, to_remove: T) -> None:
+        ...
+
+    def update(self, new_values: Iterable[T]) -> None:
+        ...

--- a/trie/utils/nodes.py
+++ b/trie/utils/nodes.py
@@ -188,7 +188,7 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
     if node_type == NODE_TYPE_LEAF:
         return HexaryTrieNode(
             sub_segments=(),
-            value=node_body[-1],
+            value=bytes(node_body[-1]),
             suffix=Nibbles(extract_key(node_body)),
             raw=node_body,
         )
@@ -199,8 +199,8 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
         )
         return HexaryTrieNode(
             sub_segments=sub_segments,
-            value=node_body[-1],
-            suffix=(),
+            value=bytes(node_body[-1]),
+            suffix=Nibbles(()),
             raw=node_body,
         )
     elif node_type == NODE_TYPE_EXTENSION:
@@ -208,7 +208,7 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
         return HexaryTrieNode(
             sub_segments=(Nibbles(key_extension), ),
             value=b'',
-            suffix=(),
+            suffix=Nibbles(()),
             raw=node_body,
         )
     elif node_type == NODE_TYPE_BLANK:
@@ -216,7 +216,7 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
         return HexaryTrieNode(
             sub_segments=(),
             value=b'',
-            suffix=(),
+            suffix=Nibbles(()),
             raw=node_body,
         )
     else:


### PR DESCRIPTION
### What was wrong?

To backfill state data in Trinity, we need some more tools to help scan the trie, keeping track of previous scan results. We need to be able to scan for nodes near an arbitrary key.

The Trinity implementation will look pretty similar to the walk section in [`test_trie_walk_root_change_with_cached_traverse_from`](https://github.com/ethereum/py-trie/pull/95/files#diff-988939f9c40d3b317a2fbbb13f12c236R398-R421)

### How was it fixed?

New class `TrieFog` to track the parts of the trie that have been explored.

New class `TrieFrontierCache` to keep a cache of recently explored nodes (in order to skip database lookups during trie traversal, by using `HexaryTrie.traverse_from()`).

Lots of tests for the trie fog, and tests about walking the trie looking for missing nodes.

Broadly, trie walk tests cover:
- iterating over all nodes using `traverse()` and trie fog
- iterating over all nodes using `traverse_from()` and trie fog
- iterating over some nodes using `traverse()` and trie fog, then modify the trie, then finish iterating
- iterating over some nodes using `traverse_from()` and trie fog, then modify the trie, then finish iterating

TODOs:
- [x] rebase on #98 
- [x] split out just `TrieFog` into PR, and rebase
- [x] use `TrieFog` in `trie/iter.py` to do basic trie iteration testing -- see #104 
- [x] remove all TODOs: either fix or open issue
- [x] type annotations
- [x] squash a lot
- [x] CHANGELOG

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/72/3d/1c/723d1ca51b9b9db2a8e84fe45a1f767a.jpg)