### PR TITLE
Add prefix to MissingTrieNode exception

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,19 @@ Breaking Changes
 - Removed trie.sync (classes: SyncRequest and HexaryTrieSync)
   New syncing helper tools are imminent.
   https://github.com/ethereum/py-trie/pull/100
+- MissingTrieNode is no longer a KeyError, paving the way for eventually raising a KeyError instead
+  of returning b'' when a key is not present in the trie
+  https://github.com/ethereum/py-trie/pull/98
+- If traversing, instead of getting a key value, then MissingTrieNode.requested_key might be None
+  https://github.com/ethereum/py-trie/pull/98
+
+Features
+~~~~~~~~
+
+- MissingTrieNode now includes the prefix of the key leading to the node body that was missing
+  from the database. This is important for other potential database layouts. The prefix may be None,
+  if it cannot be determined. For now, it will not be determined when setting or deleting a key.
+  https://github.com/ethereum/py-trie/pull/98
 
 Bugfixes
 ~~~~~~~~

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,35 @@
+import pytest
+
+from trie.exceptions import MissingTrieNode
+
+
+@pytest.mark.parametrize(
+    'valid_prefix',
+    (
+        None,
+        (),
+        (0, 0, 0),
+        (0xf, ) * 128,  # no length limit on the prefix
+    ),
+)
+def test_valid_MissingTrieNode_prefix(valid_prefix):
+    exception = MissingTrieNode(b'', b'', b'', valid_prefix)
+    assert exception.prefix == valid_prefix
+
+
+@pytest.mark.parametrize(
+    'invalid_prefix, exception',
+    (
+        ((b'F', ), ValueError),
+        (b'F', TypeError),
+        ((b'\x00', ), ValueError),
+        ((b'\x0F', ), ValueError),
+        (0, TypeError),
+        (0xf, TypeError),
+        ((0, 0x10), ValueError),
+        ((0, -1), ValueError),
+    ),
+)
+def test_invalid_MissingTrieNode_prefix(invalid_prefix, exception):
+    with pytest.raises(exception):
+        MissingTrieNode(b'', b'', b'', invalid_prefix)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,39 @@
+import pytest
+
+from trie.typing import (
+    Nibbles,
+)
+
+
+@pytest.mark.parametrize(
+    'valid_nibbles',
+    (
+        (),
+        (0, 0, 0),
+        (0xf, ) * 128,  # no length limit on the nibbles
+        [0],  # list is an acceptable input to nibbles, though will be converted to tuple
+    ),
+)
+def test_valid_nibbles(valid_nibbles):
+    typed_nibbles = Nibbles(valid_nibbles)
+    assert typed_nibbles == tuple(valid_nibbles)
+
+
+@pytest.mark.parametrize(
+    'invalid_nibbles, exception',
+    (
+        (None, TypeError),
+        ({0}, TypeError),  # unordered set is not valid input
+        ((b'F', ), ValueError),
+        (b'F', TypeError),
+        ((b'\x00', ), ValueError),
+        ((b'\x0F', ), ValueError),
+        (0, TypeError),
+        (0xf, TypeError),
+        ((0, 0x10), ValueError),
+        ((0, -1), ValueError),
+    ),
+)
+def test_invalid_nibbles(invalid_nibbles, exception):
+    with pytest.raises(exception):
+        Nibbles(invalid_nibbles)

--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -31,30 +31,45 @@ class SyncRequestAlreadyProcessed(Exception):
     pass
 
 
-class MissingTrieNode(KeyError):
+class MissingTrieNode(Exception):
     """
     Raised when a node of the trie is not available in the database,
-    for the given key in the current state root.
+    in the current state root.
 
-    Subclasses KeyError for backwards compatibility.
+    This may happen when trying to read out the value of a key, or when simply
+    traversing the trie.
     """
-    def __init__(self, missing_node_hash, root_hash, requested_key, *args):
+    def __init__(self, missing_node_hash, root_hash, requested_key, prefix=None, *args):
         if not isinstance(missing_node_hash, bytes):
             raise TypeError("Missing node hash must be bytes, was: %r" % missing_node_hash)
         elif not isinstance(root_hash, bytes):
             raise TypeError("Root hash must be bytes, was: %r" % root_hash)
-        elif not isinstance(requested_key, bytes):
-            raise TypeError("Requested key must be bytes, was: %r" % requested_key)
+        elif requested_key is not None and not isinstance(requested_key, bytes):
+            raise TypeError("Requested key must be bytes or None, was: %r" % requested_key)
 
-        super().__init__(missing_node_hash, root_hash, requested_key, *args)
+        if prefix is not None:
+            from trie.validation import validate_is_nibbles
+            try:
+                validate_is_nibbles(prefix)
+            except ValidationError:
+                raise TypeError("Key prefix must be tuple of ints 0-15, was: %r" % requested_key)
+
+        super().__init__(missing_node_hash, root_hash, requested_key, prefix, *args)
 
     def __repr__(self):
-        return "MissingTrieNode: {}".format(self)
+        return (
+            f"MissingTrieNode({self.missing_node_hash}, {self.root_hash}, "
+            f"{self.requested_key}, prefix={self.prefix})"
+        )
 
     def __str__(self):
-        return "Trie database is missing hash {} needed to look up key {} at root hash {}".format(
+        return (
+            "Trie database is missing hash {} needed to look up node at prefix {}, "
+            "when searching for key {} at root hash {}"
+        ).format(
             encode_hex(self.missing_node_hash),
-            encode_hex(self.requested_key),
+            self.prefix if self.prefix is not None else "<NO_PREFIX>",
+            encode_hex(self.requested_key) if self.requested_key is not None else "<NO_KEY>",
             encode_hex(self.root_hash),
         )
 
@@ -69,3 +84,12 @@ class MissingTrieNode(KeyError):
     @property
     def requested_key(self):
         return self.args[2]
+
+    @property
+    def prefix(self):
+        """
+        The tuple of nibbles that navigate to the missing node. For example, a missing
+        root would have a prefix of (), and a missing left-most child of the
+        root would have a prefix of (0, ).
+        """
+        return self.args[3]

--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -1,6 +1,9 @@
 from eth_utils import (
     encode_hex,
 )
+from trie.typing import (
+    Nibbles,
+)
 
 
 class InvalidNibbles(Exception):
@@ -48,13 +51,11 @@ class MissingTrieNode(Exception):
             raise TypeError("Requested key must be bytes or None, was: %r" % requested_key)
 
         if prefix is not None:
-            from trie.validation import validate_is_nibbles
-            try:
-                validate_is_nibbles(prefix)
-            except ValidationError:
-                raise TypeError("Key prefix must be tuple of ints 0-15, was: %r" % requested_key)
+            prefix_nibbles = Nibbles(prefix)
+        else:
+            prefix_nibbles = None
 
-        super().__init__(missing_node_hash, root_hash, requested_key, prefix, *args)
+        super().__init__(missing_node_hash, root_hash, requested_key, prefix_nibbles, *args)
 
     def __repr__(self):
         return (

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -1,0 +1,35 @@
+import enum
+
+from eth_utils import (
+    is_list_like,
+)
+
+
+class Nibble(enum.IntEnum):
+    Hex0 = 0
+    Hex1 = 1
+    Hex2 = 2
+    Hex3 = 3
+    Hex4 = 4
+    Hex5 = 5
+    Hex6 = 6
+    Hex7 = 7
+    Hex8 = 8
+    Hex9 = 9
+    HexA = 0xA
+    HexB = 0xB
+    HexC = 0xC
+    HexD = 0xD
+    HexE = 0xE
+    HexF = 0xF
+
+    def __repr__(self):
+        return hex(self.value)
+
+
+class Nibbles(tuple):
+    def __new__(cls, nibbles):
+        if not is_list_like(nibbles):
+            raise TypeError(f"Must pass in a tuple of nibbles, but got {nibbles!r}")
+        else:
+            return tuple.__new__(cls, (Nibble(maybe_nibble) for maybe_nibble in nibbles))

--- a/trie/validation.py
+++ b/trie/validation.py
@@ -1,3 +1,7 @@
+from eth_utils import (
+    is_integer,
+)
+
 from trie.constants import (
     BLANK_NODE,
     BLANK_HASH,
@@ -16,6 +20,11 @@ def validate_is_bytes(value):
 def validate_length(value, length):
     if len(value) != length:
         raise ValidationError("Value is of length {0}.  Must be {1}".format(len(value), length))
+
+
+def validate_is_nibbles(value):
+    if not all(is_integer(nibble) and 0 <= nibble < 16 for nibble in value):
+        raise ValidationError(f"Series of nibbles includes a non-nibble: {value!r}")
 
 
 def validate_is_node(node):

--- a/trie/validation.py
+++ b/trie/validation.py
@@ -1,7 +1,3 @@
-from eth_utils import (
-    is_integer,
-)
-
 from trie.constants import (
     BLANK_NODE,
     BLANK_HASH,
@@ -20,11 +16,6 @@ def validate_is_bytes(value):
 def validate_length(value, length):
     if len(value) != length:
         raise ValidationError("Value is of length {0}.  Must be {1}".format(len(value), length))
-
-
-def validate_is_nibbles(value):
-    if not all(is_integer(nibble) and 0 <= nibble < 16 for nibble in value):
-        raise ValidationError(f"Series of nibbles includes a non-nibble: {value!r}")
 
 
 def validate_is_node(node):


### PR DESCRIPTION
### What was wrong?

Some future requirements are to:
- get the prefix of the key used to navigate down to a trie node that then raises a `MissingTrieNode` exception
- traverse the trie directly to a node, using a series of nibbles

### How was it fixed?

Requires traversing down the nodes in a different way.

Includes another breaking change: Drop `KeyError` as a superclass of `MissingTrieNode`.

(This is an extraction from #95 )

TODO:
- [x] rebase on #97 to drop py3.5 support (PR uses f-strings)
- [x] ~maybe merge with the other trie `iter` utility~ (After adding `TrieFog`)
- [x] add release note about breaking changes

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/1b/5a/6f/1b5a6fcfdf289955075e7f8703d69111.jpg)
