### PR TITLE
Remove unnecessary node read

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ Unreleased
   prune out a node that was still required. This is fixed for fresh databases, and unfixable
   for existing databases. (Prune is not designed for on-disk/existing DBs anyhow)
   https://github.com/ethereum/py-trie/pull/93
+- Avoid reading root node when unnecessary during squash_changes(). This can be important when
+  building a witness, if the witness is supposed to be empty. (for example, in storage tries)
+  https://github.com/ethereum/py-trie/pull/101
 
 1.4.0
 ----------

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -221,6 +221,22 @@ def test_hexary_trie_at_root_lookups():
                 assert key not in snapshot
 
 
+def test_hexary_trie_empty_squash_does_not_read_root():
+    db = {}
+    trie = HexaryTrie(db=db)
+    trie[b'AAA'] = b'LONG'*32
+    trie[b'BBB'] = b'LONG'*32
+    trie[b'\xffEE'] = b'LONG'*32
+
+    flagged_usage_db = KeyAccessLogger(db)
+    flag_trie = HexaryTrie(flagged_usage_db, root_hash=trie.root_hash)
+    with flag_trie.squash_changes():
+        # root node should not be read if no changes are made during squash
+        pass
+
+    assert len(flagged_usage_db.read_keys) == 0
+
+
 @pytest.mark.parametrize(
     'name, updates, expected, deleted, final_root',
     FIXTURES_PERMUTED,

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -601,13 +601,13 @@ class HexaryTrie:
         with scratch_db.batch_commit(do_deletes=self.is_pruning):
             memory_trie = type(self)(scratch_db, self.root_hash, prune=True)
             yield memory_trie
-        try:
-            self.root_node = memory_trie.root_node
-        except MissingTrieNode:
-            # if the new root node is missing,
-            #   (or no changes happened in a squash trie where the old root node was missing),
-            #   then we shouldn't crash here
-            self.root_hash = memory_trie.root_hash
+
+        if self.root_hash != memory_trie.root_hash:
+            try:
+                self.root_node = memory_trie.root_node
+            except MissingTrieNode:
+                # if the new root node is missing, then we shouldn't crash here
+                self.root_hash = memory_trie.root_hash
 
     @contextlib.contextmanager
     def at_root(self, at_root_hash):


### PR DESCRIPTION
### What was wrong?

The `squash_changes` was *always* reading the root node, even if the trie was never modified. The correct behavior here is to not read out the root node from the database.

This might be relevant when building witnesses.

### How was it fixed?

Check if the root hash changed, before reading out the old root node from the database.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/b9/e0/b0/b9e0b0c883ef8a49c93d1c1f351034cd.jpg)