### PR TITLE
Add HexaryTrie.traverse() and .traverse_from()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,8 +12,9 @@ Breaking Changes
 - MissingTrieNode is no longer a KeyError, paving the way for eventually raising a KeyError instead
   of returning b'' when a key is not present in the trie
   https://github.com/ethereum/py-trie/pull/98
-- If traversing, instead of getting a key value, then MissingTrieNode.requested_key might be None
-  https://github.com/ethereum/py-trie/pull/98
+- If a trie body is missing when calling HexaryTrie.root_node, the exception will be
+  MissingTraversalNode instead of MissingTrieNode
+  https://github.com/ethereum/py-trie/pull/102
 
 Features
 ~~~~~~~~
@@ -22,6 +23,20 @@ Features
   from the database. This is important for other potential database layouts. The prefix may be None,
   if it cannot be determined. For now, it will not be determined when setting or deleting a key.
   https://github.com/ethereum/py-trie/pull/98
+- New HexaryTrie.traverse(tuple_of_nibbles) returns an annotated trie node found at the
+  given path of nibbles, starting from the root.
+  https://github.com/ethereum/py-trie/pull/102
+- New HexaryTrie.traverse_from(node_body, tuple_of_nibbles) returns an annotated trie node found
+  when navigating from the given node_body down through the given path of nibbles. Useful for
+  avoiding database reads when the parent node body is known. Otherwise, navigating down from
+  the root would be required every time.
+  https://github.com/ethereum/py-trie/pull/102
+- New MissingTraversalNode exception, analogous to MissingTrieNode, but when traversing
+  (because key is not available, and root_hash not available during traverse_from())
+  https://github.com/ethereum/py-trie/pull/102
+- New TraversedPartialPath exception, raised when you try to navigate to a node, but end up
+  part-way inside an extension node, or try to navigate into a leaf node.
+  https://github.com/ethereum/py-trie/pull/102
 
 Bugfixes
 ~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,9 @@ setup(
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
         "eth-utils>=1.3.0,<2.0.0",
+        "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<2",
+        "typing-extensions==3.7.4.2",
     ],
     extras_require=extras_require,
     license="MIT",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,12 @@
 import pytest
 
-from trie.exceptions import MissingTrieNode
+from trie.exceptions import (
+    MissingTraversalNode,
+    MissingTrieNode,
+    TraversedPartialPath,
+)
+from trie.typing import Nibbles
+from trie.utils.nodes import annotate_node
 
 
 @pytest.mark.parametrize(
@@ -15,6 +21,8 @@ from trie.exceptions import MissingTrieNode
 def test_valid_MissingTrieNode_prefix(valid_prefix):
     exception = MissingTrieNode(b'', b'', b'', valid_prefix)
     assert exception.prefix == valid_prefix
+    if valid_prefix is not None:
+        assert str(Nibbles(valid_prefix)) in repr(exception)
 
 
 @pytest.mark.parametrize(
@@ -33,3 +41,69 @@ def test_valid_MissingTrieNode_prefix(valid_prefix):
 def test_invalid_MissingTrieNode_prefix(invalid_prefix, exception):
     with pytest.raises(exception):
         MissingTrieNode(b'', b'', b'', invalid_prefix)
+
+
+@pytest.mark.parametrize(
+    'valid_nibbles',
+    (
+        (),
+        (0, 0, 0),
+        (0xf, ) * 128,  # no length limit on the nibbles
+    ),
+)
+def test_valid_MissingTraversalNode_nibbles(valid_nibbles):
+    exception = MissingTraversalNode(b'', valid_nibbles)
+    assert exception.nibbles_traversed == valid_nibbles
+    assert str(Nibbles(valid_nibbles)) in repr(exception)
+
+
+@pytest.mark.parametrize(
+    'invalid_nibbles, exception',
+    (
+        (None, TypeError),
+        ((b'F', ), ValueError),
+        (b'F', TypeError),
+        ((b'\x00', ), ValueError),
+        ((b'\x0F', ), ValueError),
+        (0, TypeError),
+        (0xf, TypeError),
+        ((0, 0x10), ValueError),
+        ((0, -1), ValueError),
+    ),
+)
+def test_invalid_MissingTraversalNode_nibbles(invalid_nibbles, exception):
+    with pytest.raises(exception):
+        MissingTraversalNode(b'', invalid_nibbles)
+
+
+@pytest.mark.parametrize(
+    'valid_nibbles',
+    (
+        (),
+        (0, 0, 0),
+        (0xf, ) * 128,  # no length limit on the nibbles
+    ),
+)
+def test_valid_TraversedPartialPath_nibbles(valid_nibbles):
+    exception = TraversedPartialPath(valid_nibbles, b'')
+    assert exception.nibbles_traversed == valid_nibbles
+    assert str(Nibbles(valid_nibbles)) in repr(exception)
+
+
+@pytest.mark.parametrize(
+    'invalid_nibbles, exception',
+    (
+        (None, TypeError),
+        ((b'F', ), ValueError),
+        (b'F', TypeError),
+        ((b'\x00', ), ValueError),
+        ((b'\x0F', ), ValueError),
+        (0, TypeError),
+        (0xf, TypeError),
+        ((0, 0x10), ValueError),
+        ((0, -1), ValueError),
+    ),
+)
+def test_invalid_TraversedPartialPath_nibbles(invalid_nibbles, exception):
+    with pytest.raises(exception):
+        TraversedPartialPath(invalid_nibbles, annotate_node(b''))

--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -1,8 +1,10 @@
-from eth_utils import (
-    encode_hex,
-)
+from typing import Optional
+
+from hexbytes import HexBytes
+
 from trie.typing import (
     Nibbles,
+    HexaryTrieNode,
 )
 
 
@@ -42,55 +44,132 @@ class MissingTrieNode(Exception):
     This may happen when trying to read out the value of a key, or when simply
     traversing the trie.
     """
-    def __init__(self, missing_node_hash, root_hash, requested_key, prefix=None, *args):
+    def __init__(
+            self,
+            missing_node_hash: 'Hash32',
+            root_hash: 'Hash32',
+            requested_key: bytes,
+            prefix: Nibbles = None,
+            *args):
+
         if not isinstance(missing_node_hash, bytes):
             raise TypeError("Missing node hash must be bytes, was: %r" % missing_node_hash)
         elif not isinstance(root_hash, bytes):
             raise TypeError("Root hash must be bytes, was: %r" % root_hash)
-        elif requested_key is not None and not isinstance(requested_key, bytes):
-            raise TypeError("Requested key must be bytes or None, was: %r" % requested_key)
+        elif not isinstance(requested_key, bytes):
+            raise TypeError("Requested key must be bytes, was: %r" % requested_key)
 
         if prefix is not None:
             prefix_nibbles = Nibbles(prefix)
         else:
             prefix_nibbles = None
 
-        super().__init__(missing_node_hash, root_hash, requested_key, prefix_nibbles, *args)
+        super().__init__(
+            HexBytes(missing_node_hash),
+            HexBytes(root_hash),
+            HexBytes(requested_key),
+            prefix_nibbles,
+            *args,
+        )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"MissingTrieNode({self.missing_node_hash}, {self.root_hash}, "
             f"{self.requested_key}, prefix={self.prefix})"
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
-            "Trie database is missing hash {} needed to look up node at prefix {}, "
-            "when searching for key {} at root hash {}"
-        ).format(
-            encode_hex(self.missing_node_hash),
-            self.prefix if self.prefix is not None else "<NO_PREFIX>",
-            encode_hex(self.requested_key) if self.requested_key is not None else "<NO_KEY>",
-            encode_hex(self.root_hash),
+            f"Trie database is missing hash {self.missing_node_hash!r} needed to look up node at"
+            f" prefix {self.prefix}, when searching for key {self.requested_key!r} at root"
+            f" hash {self.root_hash!r}"
         )
 
     @property
-    def missing_node_hash(self):
+    def missing_node_hash(self) -> HexBytes:
         return self.args[0]
 
     @property
-    def root_hash(self):
+    def root_hash(self) -> HexBytes:
         return self.args[1]
 
     @property
-    def requested_key(self):
+    def requested_key(self) -> HexBytes:
         return self.args[2]
 
     @property
-    def prefix(self):
+    def prefix(self) -> Optional[Nibbles]:
         """
         The tuple of nibbles that navigate to the missing node. For example, a missing
         root would have a prefix of (), and a missing left-most child of the
         root would have a prefix of (0, ).
         """
         return self.args[3]
+
+
+class MissingTraversalNode(Exception):
+    """
+    Raised when a node of the trie is not available in the database,
+    during HexaryTrie.traverse() or .traverse_from().
+
+    This is triggered in the same situation as MissingTrieNode, but with less
+    information available, because traversal can start from the middle of a trie.
+        - traverse_from() ignore's the trie's root, so the root hash is unknown
+        - the requested_key and prefix are unavailable because only the suffix of the key is known
+    """
+    def __init__(self, missing_node_hash: 'Hash32', nibbles_traversed: Nibbles, *args) -> None:
+        if not isinstance(missing_node_hash, bytes):
+            raise TypeError("Missing node hash must be bytes, was: %r" % missing_node_hash)
+
+        super().__init__(HexBytes(missing_node_hash), Nibbles(nibbles_traversed), *args)
+
+    def __repr__(self) -> str:
+        return f"MissingTraversalNode({self.missing_node_hash}, {self.nibbles_traversed})"
+
+    def __str__(self) -> str:
+        return (
+            f"Trie database is missing hash {self.missing_node_hash!r}, found when traversing "
+            f"down {self.nibbles_traversed}."
+        )
+
+    @property
+    def missing_node_hash(self) -> HexBytes:
+        return self.args[0]
+
+    @property
+    def nibbles_traversed(self) -> Nibbles:
+        """
+        Nibbles traversed down from the starting node to the missing node.
+        """
+        return self.args[1]
+
+
+class TraversedPartialPath(Exception):
+    """
+    Raised when a traversal key ends in the middle of a partial path. It might be in
+    an extension node or a leaf node.
+    """
+    def __init__(self, nibbles_traversed: Nibbles, node: HexaryTrieNode, *args) -> None:
+        # TODO drop Nibbles() cast when type checking is turned on
+        super().__init__(Nibbles(nibbles_traversed), node, *args)
+
+    def __repr__(self) -> str:
+        return f"TraversedPartialPath({self.nibbles_traversed}, {self.node})"
+
+    def __str__(self) -> str:
+        return f"Could not traverse through {self.node} at {self.nibbles_traversed}"
+
+    @property
+    def nibbles_traversed(self) -> Nibbles:
+        """
+        The nibbles traversed until the attached node, which could not be traversed into.
+        """
+        return self.args[0]
+
+    @property
+    def node(self) -> HexaryTrieNode:
+        """
+        The node which could not be traversed into. This is any leaf, or an extension node
+        where traversal went part-way into the path. It must not be a branch node.
+        """
+        return self.args[1]

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -1,8 +1,38 @@
 import enum
+from typing import (
+    List,
+    NamedTuple,
+    Tuple,
+    Union,
+)
+from typing_extensions import (
+    Literal,
+)
 
 from eth_utils import (
     is_list_like,
 )
+
+
+# The RLP-decoded node is either blank, or a list, full of bytes or recursive nodes
+# Recursive definitions don't seem supported at the moment, follow:
+#   https://github.com/python/mypy/issues/731
+# Another option is to manually declare a few levels of the type. It should be possible
+#   to determine the maximum number of embeds with single-nibble keys and single byte values.
+RawHexaryNode = Union[
+    # Blank node
+    Literal[b''],
+
+    # Leaf or extension node are length 2
+    # Branch node is length 17
+    List[Union[
+        # keys, hashes to next nodes, and values
+        bytes,
+
+        # embedded subnodes
+        "RawHexaryNode",
+    ]],
+]
 
 
 class Nibble(enum.IntEnum):
@@ -33,3 +63,38 @@ class Nibbles(tuple):
             raise TypeError(f"Must pass in a tuple of nibbles, but got {nibbles!r}")
         else:
             return tuple.__new__(cls, (Nibble(maybe_nibble) for maybe_nibble in nibbles))
+
+
+class HexaryTrieNode(NamedTuple):
+    """
+    Public API for a node of a trie, it is pre-processed a bit for simplicity.
+    """
+
+    sub_segments: Tuple[Nibbles, ...]
+    """
+    Sub segments are the _complete_ list of possible subkeys.
+    All sub segments *not* listed can be considered to not exist.
+
+    Each sub segment does not include the trie node prefix. For example:
+        - Branch nodes have length-1 tuples as sub_segments.
+        - Leaf nodes have no sub_segments
+        - Extension nodes have one sub_segment
+    """
+
+    value: bytes
+    """
+    This is the value associated with the key which navigates to this node in
+    the trie. If empty, will be set to b''.
+    """
+
+    suffix: Nibbles
+    """
+    In a leaf node, there is a suffix of a key remaining before the value is reached.
+    This is that series of nibbles. On a branch node with a value, the suffix will be ().
+    """
+
+    raw: RawHexaryNode
+    """
+    The node body, which is useful for calls to HexaryTrie.traverse_from(...),
+    for faster access of sub-nodes.
+    """

--- a/trie/utils/nodes.py
+++ b/trie/utils/nodes.py
@@ -23,6 +23,7 @@ from trie.utils.binaries import (
 )
 from trie.typing import (
     HexaryTrieNode,
+    Nibbles,
     RawHexaryNode,
 )
 from trie.validation import (
@@ -188,11 +189,14 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
         return HexaryTrieNode(
             sub_segments=(),
             value=node_body[-1],
-            suffix=extract_key(node_body),
+            suffix=Nibbles(extract_key(node_body)),
             raw=node_body,
         )
     elif node_type == NODE_TYPE_BRANCH:
-        sub_segments = tuple((nibble,) for nibble in range(16) if bool(node_body[nibble]))
+        sub_segments = tuple(
+           Nibbles((nibble,))
+           for nibble in range(16) if bool(node_body[nibble])
+        )
         return HexaryTrieNode(
             sub_segments=sub_segments,
             value=node_body[-1],
@@ -202,7 +206,7 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
     elif node_type == NODE_TYPE_EXTENSION:
         key_extension = extract_key(node_body)
         return HexaryTrieNode(
-            sub_segments=(key_extension, ),
+            sub_segments=(Nibbles(key_extension), ),
             value=b'',
             suffix=(),
             raw=node_body,

--- a/trie/utils/nodes.py
+++ b/trie/utils/nodes.py
@@ -21,6 +21,10 @@ from trie.utils.binaries import (
     encode_from_bin_keypath,
     decode_to_bin_keypath,
 )
+from trie.typing import (
+    HexaryTrieNode,
+    RawHexaryNode,
+)
 from trie.validation import (
     validate_length,
     validate_is_bytes,
@@ -173,3 +177,43 @@ def encode_leaf_node(value):
     if value is None or value == b'':
         raise ValidationError("Value of leaf node can not be empty")
     return LEAF_TYPE_PREFIX + value
+
+
+def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
+    """
+    Normalize the raw node body to a HexaryTrieNode, for external consumption.
+    """
+    node_type = get_node_type(node_body)
+    if node_type == NODE_TYPE_LEAF:
+        return HexaryTrieNode(
+            sub_segments=(),
+            value=node_body[-1],
+            suffix=extract_key(node_body),
+            raw=node_body,
+        )
+    elif node_type == NODE_TYPE_BRANCH:
+        sub_segments = tuple((nibble,) for nibble in range(16) if bool(node_body[nibble]))
+        return HexaryTrieNode(
+            sub_segments=sub_segments,
+            value=node_body[-1],
+            suffix=(),
+            raw=node_body,
+        )
+    elif node_type == NODE_TYPE_EXTENSION:
+        key_extension = extract_key(node_body)
+        return HexaryTrieNode(
+            sub_segments=(key_extension, ),
+            value=b'',
+            suffix=(),
+            raw=node_body,
+        )
+    elif node_type == NODE_TYPE_BLANK:
+        # empty trie
+        return HexaryTrieNode(
+            sub_segments=(),
+            value=b'',
+            suffix=(),
+            raw=node_body,
+        )
+    else:
+        raise NotImplementedError()


### PR DESCRIPTION
These are useful for inspecting trie structure (like when walking the
database to validate presence of all nodes). Traverse_from in particular
is helpful for caching, so you don't need to re-navigate from the root
every time.

TODO:
- [x] test `traverse_from` `MissingTraversalNode`
- [x] drop allowing requested_key = None
- [x] fix changelog for ^
- [x] new changelog entry
- [x] `missing_node_hash` of `MissingTrieNode` to `HexBytes` also
- [x] trie.root_node -> `MissingTraversalNode` error
- [x] test ^
- [x] CAP
- [x] issue to annotate root_node #103 
- [x] squash lots of commits

#### Cute Animal Picture

![Cute animal picture](https://static.boredpanda.com/blog/wp-content/uploads/2020/04/cat-and-dog-challenge-fb36-png__700.jpg) *It's possible I'm the dog*
