### PR TITLE
Convert Node iterator to use trie fog

### DIFF
--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -32,18 +32,6 @@ def _make_trie(keys):
     return node_db, trie
 
 
-def _all_keys(trie):
-    """
-    Iterate through all keys in a trie
-    """
-    # TODO: delete me after NodeIterator.all() is added
-    iterator = NodeIterator(trie)
-    key = iterator.next(b'')
-    while key is not None:
-        yield key
-        key = iterator.next(key)
-
-
 @given(
     st.lists(
         st.binary(min_size=3, max_size=3),
@@ -99,7 +87,8 @@ def test_trie_walk_backfilling(trie_keys, index_nibbles):
     # Make sure the fog agrees that it's completed
     assert fog.is_complete
     # Make sure we can walk the whole trie without any missing nodes
-    found_keys = set(_all_keys(trie))
+    iterator = NodeIterator(trie)
+    found_keys = set(iterator.all())
     # Make sure we found all the keys
     assert found_keys == set(trie_keys)
 
@@ -162,7 +151,8 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
     # Make sure the fog agrees that it's completed
     assert fog.is_complete
     # Make sure we can walk the whole trie without any missing nodes
-    found_keys = set(_all_keys(trie))
+    iterator = NodeIterator(trie)
+    found_keys = set(iterator.all())
     # Make sure we found all the keys
     assert found_keys == set(trie_keys)
 
@@ -330,7 +320,8 @@ def test_trie_walk_root_change_with_traverse(
     # We do *not* know that we have replaced all the missing_nodes, because of the trie changes
 
     # Make sure we can walk the whole trie without any missing nodes
-    found_keys = set(_all_keys(trie))
+    iterator = NodeIterator(trie)
+    found_keys = set(iterator.all())
     assert found_keys == expected_final_keys
 
 
@@ -502,5 +493,6 @@ def test_trie_walk_root_change_with_cached_traverse_from(
     # We do *not* know that we have replaced all the missing_nodes, because of the trie changes
 
     # Make sure we can walk the whole trie without any missing nodes
-    found_keys = set(_all_keys(trie))
+    iterator = NodeIterator(trie)
+    found_keys = set(iterator.all())
     assert found_keys == expected_final_keys

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -10,6 +10,7 @@ from hypothesis import (
 )
 
 from trie import HexaryTrie
+from trie.exceptions import MissingTraversalNode
 from trie.iter import NodeIterator
 from trie.utils.nodes import is_extension_node
 from .utils import make_random_trie
@@ -60,6 +61,18 @@ def test_iter(random):
     assert visited == sorted(contents.keys())
 
 
+@given(random=strategies.randoms())
+@settings(max_examples=10, deadline=500)
+def test_iter_all(random):
+    trie, contents = make_random_trie(random)
+    node_iterator = NodeIterator(trie)
+    visited = []
+    for key in node_iterator.all():
+        visited.append(key)
+    assert len(visited) > 0
+    assert visited == sorted(contents.keys())
+
+
 def test_iter_error():
     trie = HexaryTrie({})
     trie[b'cat'] = b'cat'
@@ -71,6 +84,6 @@ def test_iter_error():
     trie.db.pop(node_to_remove)
     iterator = NodeIterator(trie)
     key = b''
-    with pytest.raises(KeyError):
+    with pytest.raises(MissingTraversalNode):
         while key is not None:
             key = iterator.next(key)

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -96,6 +96,7 @@ class HexaryTrieNode(NamedTuple):
     """
     Sub segments are the _complete_ list of possible subkeys.
     All sub segments *not* listed can be considered to not exist.
+    Sub segments are sorted.
 
     Each sub segment does not include the trie node prefix. For example:
         - Branch nodes have length-1 tuples as sub_segments.


### PR DESCRIPTION
### What was wrong?

There was a concern that the trie iterator was slow and (maybe more importantly) "convoluted" because it digs into a lot of trie internals. Now, the traversal APIs are available, which should make it a bit easier to follow. Also, with `HexaryTrieFog` and `TrieFrontierCache`, it is possible to speed it up a bit when iterating over all values sequentially.

### How was it fixed?

TODO
- [x] Rebase on #95 
- [x] squash commits

#### Cute Animal Picture

![Cute animal picture](https://live.staticflickr.com/8220/8405942774_7477d34ee2_z.jpg)