### PR TITLE
Annotate HexaryTrie.root_node, and remove setter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,7 +31,7 @@ Features
 - New HexaryTrie.traverse(tuple_of_nibbles) returns an annotated trie node found at the
   given path of nibbles, starting from the root.
   https://github.com/ethereum/py-trie/pull/102
-- New HexaryTrie.traverse_from(node_body, tuple_of_nibbles) returns an annotated trie node found
+- New HexaryTrie.traverse_from(node, tuple_of_nibbles) returns an annotated trie node found
   when navigating from the given node_body down through the given path of nibbles. Useful for
   avoiding database reads when the parent node body is known. Otherwise, navigating down from
   the root would be required every time.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,11 @@ Breaking Changes
 - If a trie body is missing when calling HexaryTrie.root_node, the exception will be
   MissingTraversalNode instead of MissingTrieNode
   https://github.com/ethereum/py-trie/pull/102
+- Remove support for setting the trie's raw root node directly, via
+  HexaryTrie.root_node = new_raw_root_node
+  https://github.com/ethereum/py-trie/pull/106
+- Return new annotated HexaryTrieNode from HexaryTrie.root_node property
+  https://github.com/ethereum/py-trie/pull/106
 
 Features
 ~~~~~~~~

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ HexaryTrieNode(sub_segments=((0xb,), (0xf,)), value=b'', suffix=(), raw=[b'', b'
 # Notice the position of the children in the 11th and 15th index
 
 # Another way to get there without loading the root node from the database is using traverse_from:
->>> assert t.traverse_from(root_node.raw, root_node.sub_segments[0]) == prefix6d792d6
+>>> assert t.traverse_from(root_node, root_node.sub_segments[0]) == prefix6d792d6
 
 # Embedded nodes can be traversed to the same way as nodes stored in the database:
 

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -223,6 +223,15 @@ def test_hexary_trie_at_root_lookups():
                 assert key not in snapshot
 
 
+def test_hexary_trie_root_node_annotation():
+    trie = HexaryTrie({})
+    trie[b'\x41A'] = b'LONG'*32
+    trie[b'\xffE'] = b'LONG'*32
+    root = trie.root_node
+
+    assert root == trie.traverse(())
+
+
 def test_hexary_trie_empty_squash_does_not_read_root():
     db = {}
     trie = HexaryTrie(db=db)
@@ -369,7 +378,7 @@ def test_squash_changes_reverts_trie_root_on_exception():
     old_root_hash = trie.root_hash
 
     # delete the node that will be used during trie fixup
-    del db[trie.root_node[0xf]]
+    del db[trie.root_node.raw[0xf]]
 
     with pytest.raises(MissingTrieNode):
         with trie.squash_changes() as memory_trie:
@@ -396,7 +405,7 @@ def test_hexary_trie_missing_node():
     trie_root_hash = trie.root_hash
 
     # delete first child of the root
-    root_node = trie.root_node
+    root_node = trie.root_node.raw
 
     first_child_hash = root_node[0]
 
@@ -458,7 +467,7 @@ def test_hexary_trie_missing_traversal_node():
     trie.set(key2, b'val2')
 
     # delete first child of the root
-    root_node = trie.root_node
+    root_node = trie.root_node.raw
 
     first_child_hash = root_node[0]
 
@@ -489,7 +498,7 @@ def test_hexary_trie_missing_traversal_node_with_traverse_from():
     trie.set(key2, b'val2')
 
     # delete first child of the root
-    root_node = trie.root_node
+    root_node = trie.root_node.raw
 
     first_child_hash = root_node[0]
 
@@ -747,7 +756,7 @@ def test_traverse_from_partial_path(
     for key, val in trie_items:
         trie[key] = val
 
-    root = trie.root_node
+    root = trie.root_node.raw
     with pytest.raises(TraversedPartialPath) as excinfo:
         trie.traverse_from(root, traverse_key)
 

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -498,9 +498,9 @@ def test_hexary_trie_missing_traversal_node_with_traverse_from():
     trie.set(key2, b'val2')
 
     # delete first child of the root
-    root_node = trie.root_node.raw
+    root_node = trie.root_node
 
-    first_child_hash = root_node[0]
+    first_child_hash = root_node.raw[0]
 
     del db[first_child_hash]
 
@@ -639,7 +639,7 @@ def test_hexary_trie_traverse(name, updates, expected, deleted, final_root):
 
         for new_child in node.sub_segments:
             # traverse into children
-            traverse_via_cache(parent_prefix + child_extension, node.raw, new_child)
+            traverse_via_cache(parent_prefix + child_extension, node, new_child)
 
     # start traversal at root
     traverse_via_cache((), None, ())
@@ -756,7 +756,7 @@ def test_traverse_from_partial_path(
     for key, val in trie_items:
         trie[key] = val
 
-    root = trie.root_node.raw
+    root = trie.root_node
     with pytest.raises(TraversedPartialPath) as excinfo:
         trie.traverse_from(root, traverse_key)
 

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -427,7 +427,7 @@ def test_trie_walk_root_change_with_cached_traverse_from(
             fog = fog.explore(nearest_prefix, node.sub_segments)
 
             if node.sub_segments:
-                cache.add(nearest_prefix, node.raw, node.sub_segments)
+                cache.add(nearest_prefix, node, node.sub_segments)
             else:
                 cache.delete(nearest_prefix)
 
@@ -491,7 +491,7 @@ def test_trie_walk_root_change_with_cached_traverse_from(
         fog = fog.explore(nearest_prefix, sub_segments)
 
         if sub_segments:
-            cache.add(nearest_prefix, node.raw, sub_segments)
+            cache.add(nearest_prefix, node, sub_segments)
         else:
             cache.delete(nearest_prefix)
     else:

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -65,8 +65,9 @@ def test_iter_error():
     trie[b'cat'] = b'cat'
     trie[b'dog'] = b'dog'
     trie[b'bird'] = b'bird'
-    assert is_extension_node(trie.root_node)
-    node_to_remove = trie.root_node[1]
+    raw_root_node = trie.root_node.raw
+    assert is_extension_node(raw_root_node)
+    node_to_remove = raw_root_node[1]
     trie.db.pop(node_to_remove)
     iterator = NodeIterator(trie)
     key = b''

--- a/trie/fog.py
+++ b/trie/fog.py
@@ -20,9 +20,9 @@ from trie.exceptions import (
 )
 from trie.typing import (
     GenericSortedSet,
+    HexaryTrieNode,
     Nibbles,
     NibblesInput,
-    RawHexaryNode,
 )
 from trie.utils.nibbles import (
     decode_nibbles,
@@ -265,15 +265,15 @@ class HexaryTrieFog:
 
 class TrieFrontierCache:
     """
-    Keep a cache of RawHexaryNode bodies for use with traverse_from. This
+    Keep a cache of HexaryTrieNodes for use with traverse_from. This
     can be used neatly with HexaryTrieFog to only keep a cache of the frontier
     of unexplored nodes, so that every expansion into a new unexplored node requires
     only one database lookup instead of log(n).
     """
     def __init__(self) -> None:
-        self._cache: Dict[Nibbles, Tuple[RawHexaryNode, Nibbles]] = {}
+        self._cache: Dict[Nibbles, Tuple[HexaryTrieNode, Nibbles]] = {}
 
-    def get(self, prefix: NibblesInput) -> Tuple[RawHexaryNode, Nibbles]:
+    def get(self, prefix: NibblesInput) -> Tuple[HexaryTrieNode, Nibbles]:
         """
         Find the cached node body of the parent of the given prefix.
 
@@ -286,7 +286,7 @@ class TrieFrontierCache:
     def add(
             self,
             node_prefix_input: NibblesInput,
-            trie_node: RawHexaryNode,
+            trie_node: HexaryTrieNode,
             sub_segments: Sequence[NibblesInput]) -> None:
 
         """

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -186,7 +186,7 @@ class HexaryTrie:
 
         return self._traverse_from(root_node, trie_key)
 
-    def traverse_from(self, node: RawHexaryNode, trie_key_input: Nibbles) -> HexaryTrieNode:
+    def traverse_from(self, parent_node: HexaryTrieNode, trie_key_input: Nibbles) -> HexaryTrieNode:
         """
         Find the node at the path of nibbles provided. You cannot navigate to the root node
         this way (without already having the root node body, to supply as the argument).
@@ -199,7 +199,7 @@ class HexaryTrie:
         """
         trie_key = Nibbles(trie_key_input)
 
-        node, remaining_key = self._traverse_from(node, trie_key)
+        node, remaining_key = self._traverse_from(parent_node.raw, trie_key)
 
         annotated_node = annotate_node(node)
 

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -400,15 +400,13 @@ class HexaryTrie:
     # Convenience
     #
     @property
-    def root_node(self):
+    def root_node(self) -> HexaryTrieNode:
         try:
-            return self.get_node(self.root_hash)
+            raw_node = self.get_node(self.root_hash)
         except KeyError:
             raise MissingTraversalNode(self.root_hash, nibbles_traversed=())
-
-    @root_node.setter
-    def root_node(self, value):
-        self._set_root_node(value)
+        else:
+            return annotate_node(raw_node)
 
     #
     # Utils
@@ -741,7 +739,7 @@ class HexaryTrie:
 
         if self.root_hash != memory_trie.root_hash:
             try:
-                self.root_node = memory_trie.root_node
+                self._set_root_node(memory_trie.root_node.raw)
             except MissingTraversalNode:
                 # if the new root node is missing, then we shouldn't crash here
                 self.root_hash = memory_trie.root_hash

--- a/trie/iter.py
+++ b/trie/iter.py
@@ -26,7 +26,7 @@ class NodeIterator:
 
     def next(self, key):
         key = bytes_to_nibbles(key)
-        nibbles = self._iter(self.trie.root_node, key)
+        nibbles = self._iter(self.trie.root_node.raw, key)
         if nibbles is None:
             return None
         return nibbles_to_bytes(remove_nibbles_terminator(nibbles))


### PR DESCRIPTION
### What was wrong?

Fix #103 

### How was it fixed?

Annotate the return value, update tests that used the raw root node, and add a new test that `HexaryTrie().root_node == HexaryTrie().traverse(())`

Also removed the setter. Do we really need it? I guess for symmetry, you would want to set with an annotated node.

Finally: Updated the `traverse_from()` API to take the new annotated node instead of the raw node. It seemed silly to return an annotated node and expect a raw one back as an argument.

TODO
- [x] squash

#### Cute Animal Picture

![Cute animal picture](https://thenypost.files.wordpress.com/2020/03/031120-cute-animals-anti-corona-10.jpg?quality=80&strip=all&w=1024)
