### PR TITLE
Prune during exception

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,27 @@
 Unreleased
 ---------------
 
-None
+Features
+~~~~~~~~
+
+- Can now use NodeIterator to navigate to the empty key b'', using NodeIterator.next(key=None) or
+  simply NodeIterator.next().
+  https://github.com/ethereum/py-trie/pull/110
+
+Bugfixes
+~~~~~~~~
+
+- In certain cases, deleting key b'short' would actually delete the key at b'short-nope-long'!
+  Changed key_starts_with() to fix it
+  https://github.com/ethereum/py-trie/pull/109
+- HexaryTrie.set(key, b'') would sometimes try to create a leaf node with an
+  empty value. Instead, it should act exactly the same as HexaryTrie.delete(key)
+  https://github.com/ethereum/py-trie/pull/109
+- When a MissingTrieNode is raised during pruning (or using squash_changes()), a node body
+  that was pruned before the exception was raised might stay pruned, even though the trie
+  wasn't updated.
+  https://github.com/ethereum/py-trie/pull/109
+
 
 v2.0.0-alpha.1
 ---------------

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -11,6 +11,12 @@ from eth_utils import (
     text_if_str,
     to_bytes,
 )
+from hypothesis import (
+    example,
+    given,
+    settings,
+    strategies as st,
+)
 import pytest
 import rlp
 
@@ -246,6 +252,165 @@ def test_hexary_trie_empty_squash_does_not_read_root():
         pass
 
     assert len(flagged_usage_db.read_keys) == 0
+
+
+@st.composite
+def trie_updates_strategy(draw, max_size=256):
+    """
+    Generate a series of key/value inserts, then create a series of (inserts, updates & deletes)
+
+    The idea of this strategy is to make sure that we get updates and deletes by reusing keys that
+    have already been created. This is necessary to create "interesting" use cases for a trie.
+    Additionally, the length of the value changes the shape of the trie, due to
+    node size, so try to vary that length as well.
+
+    :returns: inserts, updates
+
+    Inserts are (key, value) pairs. Updates are one of:
+        - single-value tuple: (key,) -- insert key with value of test's choosing
+        - double-value tuple: (key, None) -- delete key with given value
+        - double-value tuple: (key, value) -- update key with given value
+
+    Note that "update" may be b'', so would be effectively a delete. But tests ought to leave this
+    as a trie "set" call, to make sure that code path is tested.
+    """
+    # starting trie keys
+    start_keys = draw(st.lists(
+        st.binary(min_size=3, max_size=3),
+        unique=True,
+        min_size=1,
+        max_size=1024,
+    ))
+
+    minimum_insert_value_length = draw(st.integers(min_value=3, max_value=32))
+
+    latest_keys = list(start_keys)
+    inserts = [
+        (key, key.ljust(minimum_insert_value_length, b'3'))
+        for key in start_keys
+    ]
+    updates = []
+
+    for _ in range(max_size):
+        # Select the next change
+        if len(latest_keys):
+            next_change = draw(st.one_of(
+                # insert
+                st.tuples(
+                    st.binary(min_size=3, max_size=3),
+                ),
+                # update
+                st.tuples(
+                    st.sampled_from(latest_keys),
+                    st.binary(min_size=1, max_size=128),
+                ),
+                # delete
+                st.tuples(
+                    st.sampled_from(latest_keys),
+                    # Sometimes run deletes as sets, sometimes as deletes.
+                    # Test code should call `del trie[key]` if value is None
+                    st.one_of(st.none(), st.just(b'')),
+                )
+            ))
+        else:
+            # If there are no current keys, then updating/deleting is not possible,
+            #   so only insert in this case.
+            next_change = draw(
+                # insert
+                st.tuples(
+                    st.binary(min_size=3, max_size=3),
+                ),
+            )
+
+        if len(next_change) == 1:
+            key = next_change[0]
+            if key in latest_keys:
+                # Inserting an existing key is not allowed (it would actually be an update), so
+                # treat it as a no-op.
+                continue
+            else:
+                latest_keys.append(key)
+                updates.append((key, key.ljust(minimum_insert_value_length, b'3')))
+        elif len(next_change) == 2:
+            updates.append(next_change)
+            key, next_val = next_change
+            if next_val in (None, b''):
+                latest_keys.remove(key)
+        else:
+            raise Exception(f"Invalid code path: next_change = {next_change}")
+
+        # on average, build an update list of length ~100, but "shrinks" down to short lists
+        should_continue = draw(st.integers(min_value=0, max_value=99))
+        if should_continue == 0:
+            break
+
+    return inserts, updates
+
+
+@given(
+    trie_updates_strategy()
+)
+@example(
+    # Triggers a case where the delete of a leaf succeeds, but the normalization fails because
+    #   of a missing trie node. The exception was *not* preventing the pruning from happening.
+    inserts_and_updates=(
+        [
+            (b'\x00\x00\x00', b'\x00\x00\x0033333333333333333333333'),
+            (b'\x01\x00\x00', b'\x01\x00\x0033333333333333333333333'),
+        ],
+        [
+            (b'\x00\x00\x00', None),
+        ]
+    )
+)
+@example(
+    # An old implementation treated trie.set(key, b'') and trie.delete(key) differently, and
+    #   this test case exposed the issue.
+    inserts_and_updates=(
+        [],
+        [
+            (b'', b''),
+            (b'', None),
+            (b'\x00', b''),
+            (b'', b''),
+            (b'\x00', None),
+        ],
+    ),
+)
+@settings(max_examples=300)
+def test_squash_changes_does_not_prune_on_missing_trie_node(inserts_and_updates):
+    inserts, updates = inserts_and_updates
+    node_db = {}
+    trie = HexaryTrie(node_db)
+    with trie.squash_changes() as trie_batch:
+        for key, value in inserts:
+            trie_batch[key] = value
+
+    missing_nodes = dict(node_db)
+    node_db.clear()
+
+    with trie.squash_changes() as trie_batch:
+        for key, value in updates:
+            # repeat until change is complete
+            change_complete = False
+            while not change_complete:
+                # Catch any missing nodes during trie change, and fix them up.
+                # This is equivalent to Trinity's "Beam Sync".
+
+                previous_db = trie_batch.db.copy()
+                try:
+                    if value is None:
+                        del trie_batch[key]
+                    else:
+                        trie_batch[key] = value
+                except MissingTrieNode as exc:
+                    # When an exception is raised, we must never change the database
+                    current_db = trie_batch.db.copy()
+                    assert current_db == previous_db
+
+                    node_db[exc.missing_node_hash] = missing_nodes.pop(exc.missing_node_hash)
+                else:
+                    change_complete = True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -442,6 +442,13 @@ def test_squash_changes_does_not_prune_on_missing_trie_node(inserts_and_updates)
     updates=[(b'', b''), (b'', b'')],
     deleted=[b''],
 )
+@example(
+    # Wow, found a bug where a deleting a missing key could delete a *different, longer* key
+    # Deleting the b'' key here will cause the b'\x01' key to get deleted!
+    updates=[(b'\x01', b'\x00'), (b'\x01\x00', b'\x00')],
+    deleted=[b''],
+)
+@settings(max_examples=1000)
 def test_hexary_trie_squash_all_changes(updates, deleted):
     db = {}
     trie = HexaryTrie(db=db)

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -284,7 +284,10 @@ class HexaryTrie:
         try:
             root_node = self.get_node(self.root_hash)
 
-            new_node = self._set(root_node, trie_key, value)
+            if value == b'':
+                new_node = self._delete(root_node, trie_key)
+            else:
+                new_node = self._set(root_node, trie_key, value)
         except KeyError as exc:
             self._raise_missing_node(exc, key)
 

--- a/trie/utils/db.py
+++ b/trie/utils/db.py
@@ -1,5 +1,11 @@
 import contextlib
 
+from eth_utils import to_dict
+from eth_utils.toolz import (
+    merge,
+    valfilter,
+)
+
 DELETED = object()
 
 
@@ -43,6 +49,11 @@ class ScratchDB:
             return True
         else:
             return key in self.wrapped_db
+
+    @to_dict
+    def copy(self):
+        combined = merge(self.wrapped_db, self.cache)
+        return valfilter(lambda val: val is not DELETED, combined)
 
     @contextlib.contextmanager
     def batch_commit(self, *, do_deletes=False):

--- a/trie/utils/nodes.py
+++ b/trie/utils/nodes.py
@@ -118,7 +118,10 @@ def consume_common_prefix(left_key, right_key):
 
 
 def key_starts_with(full_key, partial_key):
-    return all(left == right for left, right in zip(full_key, partial_key))
+    if len(full_key) < len(partial_key):
+        return False
+    else:
+        return all(left == right for left, right in zip(full_key, partial_key))
 
 
 # Binary Trie node utils


### PR DESCRIPTION
### What was wrong?

While working on #108, I wrote a hypothesis test that uncovered ~3 new bugs, including a really spooky one:

- in certain cases, `del trie[b'short']` would actually delete the key at `b'short-nope-long'`!
- `trie.set(key, b'')` would sometimes (always?) try to create a leaf node with an empty value. Instead, it should act exactly the same as `del trie[key]`
- when a `MissingTrieException` was raised during `squash_changes()` (really, any time `pruning=True`), there were times when it would prune away a node and then raise an exception. In other words, it would remove a trie node we need to walk the trie from before the change attempt.
- ~`NodeIterator.next()` didn't have any way to iterate to the `b''` key.~ Moved to #110 

### How was it fixed?

- fixed `key_starts_with(complete_key, partial_key)` to return `True` only if the entire `partial_key` is present in `complete_key`. Formerly, `key_starts_with((), (1, 0))` would `return True`, which I found surprising, and apparently so did whomever implemented `delete_kv_node()`.
- just dispatch `set(key, b'')` to `delete(key)`
- Re-worked pruning: instead of immediately deleting nodes, the trie queues up all the pruning events to be triggered only at the very end of a `set()` or `delete()`.

TODO:
- [x] CHANGELOG
- [x] squash commits

#### Cute Animal Picture

![Cute animal picture](https://cdn.abcotvs.com/dip/images/476626_011515-cc-ErmineThumb.jpg?w=1280&r=16%3A9)