### PR TITLE
Make iter test much faster, run more examples

### DIFF
--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -6,14 +6,13 @@ import pytest
 from hypothesis import (
     given,
     settings,
-    strategies,
 )
 
 from trie import HexaryTrie
 from trie.exceptions import MissingTraversalNode
 from trie.iter import NodeIterator
 from trie.utils.nodes import is_extension_node
-from .utils import make_random_trie
+from .utils import random_trie_strategy
 
 
 ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -47,29 +46,34 @@ def test_trie_next_prev_using_fixtures(fixture_name, fixture):
         assert nxt == iterator.next(point)
 
 
-@given(random=strategies.randoms())
-@settings(max_examples=10, deadline=500)
-def test_iter(random):
-    trie, contents = make_random_trie(random)
+@given(random_trie_strategy())
+@settings(max_examples=200)
+def test_iter(random_trie):
+    trie, contents = random_trie
     iterator = NodeIterator(trie)
-    visited = []
-    key = iterator.next(b'')
-    assert key is not None
-    while key is not None:
-        visited.append(key)
-        key = iterator.next(key)
-    assert visited == sorted(contents.keys())
+
+    key = iterator.next()
+
+    if len(contents) == 0:
+        assert key is None
+    else:
+        assert key is not None
+
+        visited = []
+        while key is not None:
+            visited.append(key)
+            key = iterator.next(key)
+        assert visited == sorted(contents.keys())
 
 
-@given(random=strategies.randoms())
-@settings(max_examples=10, deadline=500)
-def test_iter_all(random):
-    trie, contents = make_random_trie(random)
+@given(random_trie_strategy())
+@settings(max_examples=200)
+def test_iter_all(random_trie):
+    trie, contents = random_trie
     node_iterator = NodeIterator(trie)
     visited = []
     for key in node_iterator.all():
         visited.append(key)
-    assert len(visited) > 0
     assert visited == sorted(contents.keys())
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,14 +1,24 @@
+from hypothesis import (
+    strategies as st,
+)
+
 from trie import HexaryTrie
 
 
-def make_random_trie(random):
+@st.composite
+def random_trie_strategy(draw):
+    trie_items = draw(st.lists(
+        st.tuples(
+            # key
+            st.binary(max_size=32),
+            # value
+            st.binary(min_size=1, max_size=64),
+        ),
+        unique=True,
+        max_size=512,
+    ))
+
     trie = HexaryTrie({})
-    contents = {}
-    for _ in range(512):
-        key_length = random.randint(2, 32)
-        key = bytes([random.randint(0, 255) for _ in range(key_length)])
-        value_length = random.randint(2, 64)
-        value = bytes([random.randint(0, 255) for _ in range(value_length)])
+    for key, value in trie_items:
         trie[key] = value
-        contents[key] = value
-    return trie, contents
+    return trie, dict(trie_items)

--- a/trie/iter.py
+++ b/trie/iter.py
@@ -32,19 +32,27 @@ class NodeIterator:
     def __init__(self, trie: HexaryTrie) -> None:
         self._trie = trie
 
-    def next(self, key_bytes: bytes) -> Optional[bytes]:
+    def next(self, key_bytes: Optional[bytes] = None) -> Optional[bytes]:
         """
         Find the next key to the right from the given key, or None if there is
         no key to the right.
 
         .. NOTE:: If you plan to iterate the full trie, use all() instead, for performance.
 
+        :param key_bytes: the key to start your search from. If None, return
+            the first possible key.
+
         :return: key in bytes to the right of key_bytes, or None
         """
         root = self._trie.root_node
-        key = bytes_to_nibbles(key_bytes)
         none_traversed = Nibbles(())
-        next_key = self._get_key_after(root, key, none_traversed)
+
+        if key_bytes is None:
+            next_key = self._get_next_key(root, none_traversed)
+        else:
+            key = bytes_to_nibbles(key_bytes)
+            next_key = self._get_key_after(root, key, none_traversed)
+
         if next_key is None:
             return None
         else:


### PR DESCRIPTION
### What was wrong?

The deadline on `test_iter` was occasionally hitting >600ms in CI, so it seemed worth a doing a rewrite.

Also, hypothesis exposed a quirk: that you can't iterate to the `b''` key using `NodeIterator.next(key)`

### How was it fixed?

Let `hypothesis` generate the trie, including keys and values just as big as before. But also allow it to be smaller in many cases.

Additionally, can now iterate to `b''` by using a new `.next(key=None)` option, which returns the first possible key.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/54/1a/a3/541aa3a50a04c88b2c1a4d050a78aada.jpg)
