### PR TITLE
Fix walk with partial traverse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,9 @@ Features
 - Can now use NodeIterator to navigate to the empty key b'', using NodeIterator.next(key=None) or
   simply NodeIterator.next().
   https://github.com/ethereum/py-trie/pull/110
+- TraversedPartialPath has a new simulated_node attribute, which we can treat as a node that
+  would have been at the traversed path if the traversal had succeeded. See the readme for more.
+  https://github.com/ethereum/py-trie/pull/111
 
 Bugfixes
 ~~~~~~~~

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,9 +4,14 @@ from trie.exceptions import (
     MissingTraversalNode,
     MissingTrieNode,
     TraversedPartialPath,
+    ValidationError,
 )
 from trie.typing import Nibbles
-from trie.utils.nodes import annotate_node
+from trie.utils.nodes import (
+    annotate_node,
+    compute_extension_key,
+    compute_leaf_key,
+)
 
 
 @pytest.mark.parametrize(
@@ -84,8 +89,11 @@ def test_invalid_MissingTraversalNode_nibbles(invalid_nibbles, exception):
         (0xf, ) * 128,  # no length limit on the nibbles
     ),
 )
-def test_valid_TraversedPartialPath_nibbles(valid_nibbles):
-    exception = TraversedPartialPath(valid_nibbles, b'')
+@pytest.mark.parametrize('key_encoding', (compute_extension_key, compute_leaf_key))
+def test_valid_TraversedPartialPath_traversed_nibbles(valid_nibbles, key_encoding):
+    some_node_key = (1, 2)
+    node = annotate_node([key_encoding(some_node_key), b'random-value'])
+    exception = TraversedPartialPath(valid_nibbles, node, some_node_key[:1])
     assert exception.nibbles_traversed == valid_nibbles
     assert str(Nibbles(valid_nibbles)) in repr(exception)
 
@@ -104,6 +112,89 @@ def test_valid_TraversedPartialPath_nibbles(valid_nibbles):
         ((0, -1), ValueError),
     ),
 )
-def test_invalid_TraversedPartialPath_nibbles(invalid_nibbles, exception):
+def test_invalid_TraversedPartialPath_traversed_nibbles(invalid_nibbles, exception):
     with pytest.raises(exception):
-        TraversedPartialPath(invalid_nibbles, annotate_node(b''))
+        TraversedPartialPath(invalid_nibbles, annotate_node(b''), (1,))
+
+
+@pytest.mark.parametrize(
+    'valid_nibbles',
+    (
+        (0, 0, 0),
+        (0xf, ) * 128,  # no length limit on the nibbles
+    ),
+)
+@pytest.mark.parametrize('key_encoding', (compute_extension_key, compute_leaf_key))
+def test_valid_TraversedPartialPath_untraversed_nibbles(valid_nibbles, key_encoding):
+    # This exception means that the actual node key should have more than the untraversed amount
+    # So we simulate some longer key for the given node
+    longer_key = valid_nibbles + (0,)
+    node = annotate_node([key_encoding(longer_key), b'random-value'])
+    exception = TraversedPartialPath((), node, valid_nibbles)
+    assert exception.untraversed_tail == valid_nibbles
+    assert str(Nibbles(valid_nibbles)) in repr(exception)
+
+
+@pytest.mark.parametrize('key_encoding', (compute_extension_key, compute_leaf_key))
+def test_TraversedPartialPath_keeps_node_value(key_encoding):
+    node_key = (0, 0xf, 9)
+    untraversed_tail = node_key[:1]
+    remaining_key = node_key[1:]
+    node_value = b'unicorns'
+    node = annotate_node([key_encoding(node_key), node_value])
+    tpp = TraversedPartialPath(node_key, node, untraversed_tail)
+    simulated_node = tpp.simulated_node
+    assert simulated_node.raw[1] == node_value
+    if key_encoding is compute_leaf_key:
+        assert simulated_node.sub_segments == ()
+        assert simulated_node.suffix == remaining_key
+        assert simulated_node.raw[0] == compute_leaf_key(remaining_key)
+        assert simulated_node.value == node_value
+    elif key_encoding is compute_extension_key:
+        assert simulated_node.sub_segments == (remaining_key, )
+        assert simulated_node.suffix == ()
+        assert simulated_node.raw[0] == compute_extension_key(remaining_key)
+    else:
+        raise Exception("Unsupported way to encode keys: {key_encoding}")
+
+
+@pytest.mark.parametrize(
+    'invalid_nibbles, node_key, exception',
+    (
+        ((), (), ValueError),
+        (None, (), TypeError),
+        ((b'F', ), (), ValueError),
+        (b'F', (), TypeError),
+        ((b'\x00', ), (), ValueError),
+        ((b'\x0F', ), (), ValueError),
+        (0, (), TypeError),
+        (0xf, (), TypeError),
+        ((0, 0x10), (), ValueError),
+        ((0, -1), (), ValueError),
+        # There must be some kind of tail
+        ((), (1,), ValueError),
+        # The untraversed tail must be a prefix of the node key
+        ((0,), (1,), ValidationError),
+        # The untraversed tail must not be the full length of the node key
+        ((1,), (1,), ValidationError),
+    ),
+)
+@pytest.mark.parametrize('key_encoding', (compute_extension_key, compute_leaf_key))
+def test_invalid_TraversedPartialPath_untraversed_nibbles(
+        invalid_nibbles,
+        node_key,
+        exception,
+        key_encoding):
+
+    if node_key == ():
+        node = annotate_node(b'')
+    else:
+        node = annotate_node([key_encoding(node_key), b'some-val'])
+
+    # Handle special case: leaf nodes are permitted to have the untraversed tail equal the suffix
+    if len(node.suffix) > 0 and node.suffix == invalid_nibbles:
+        # So in this one case, make sure we don't raise an exception
+        TraversedPartialPath((), node, invalid_nibbles)
+    else:
+        with pytest.raises(exception):
+            TraversedPartialPath((), node, invalid_nibbles)

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -18,13 +18,10 @@ from trie.typing import Nibbles
 
 
 @given(
-    st.lists(
-        st.binary(min_size=3, max_size=3),
-        unique=True,
-        max_size=1024,
-    ),
+    # starting trie keys
+    trie_keys_with_extensions(allow_empty_trie=False),
     # minimum value length (to help force trie nodes to stop embedding)
-    st.integers(min_value=3, max_value=32),
+    st.integers(min_value=1, max_value=32),
     st.lists(
         st.integers(min_value=0, max_value=0xf),
         max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
@@ -81,13 +78,10 @@ def test_trie_walk_backfilling(trie_keys, minimum_value_length, index_nibbles):
 
 
 @given(
-    st.lists(
-        st.binary(min_size=3, max_size=3),
-        unique=True,
-        max_size=1024,
-    ),
+    # starting trie keys
+    trie_keys_with_extensions(allow_empty_trie=False),
     # minimum value length (to help force trie nodes to stop embedding)
-    st.integers(min_value=3, max_value=32),
+    st.integers(min_value=1, max_value=32),
     st.lists(
         st.integers(min_value=0, max_value=0xf),
         max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -37,7 +37,7 @@ def test_trie_walk_backfilling(trie_keys, index_nibbles):
     - Every time a node is missing from the DB, replace it and retry
     - Repeat until full trie has been explored with the HexaryTrieFog
     """
-    node_db, trie = trie_from_keys(trie_keys)
+    node_db, trie = trie_from_keys(trie_keys, prune=True)
     index_key = Nibbles(index_nibbles)
 
     # delete all nodes
@@ -94,7 +94,7 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
     """
     Like test_trie_walk_backfilling but using the HexaryTrie.traverse_from API
     """
-    node_db, trie = trie_from_keys(trie_keys)
+    node_db, trie = trie_from_keys(trie_keys, prune=True)
     index_key = Nibbles(index_nibbles)
 
     # delete all nodes
@@ -195,6 +195,16 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
     index_nibbles=[],
     index_nibbles2=[],
 )
+@example(
+    # This is the example that inspired test_squash_a_pruning_trie_keeps_unchanged_short_root_node
+    # Leave it in as a backup regression test, and to test in a broader context.
+    trie_keys=[b'\x00\x00\x01'],
+    minimum_value_length=0,
+    number_explorations=0,
+    trie_changes=[b'\x00\x00\x01'],
+    index_nibbles=[],
+    index_nibbles2=[],
+)
 def test_trie_walk_root_change_with_traverse(
         trie_keys,
         minimum_value_length,
@@ -211,7 +221,7 @@ def test_trie_walk_root_change_with_traverse(
     - Verify that all required database values were replaced (where only the nodes under
         the NEW trie root are required)
     """
-    node_db, trie = trie_from_keys(trie_keys)
+    node_db, trie = trie_from_keys(trie_keys, prune=True)
 
     number_explorations %= len(node_db)
 
@@ -363,7 +373,7 @@ def test_trie_walk_root_change_with_cached_traverse_from(
     Like test_trie_walk_root_change_with_traverse but using HexaryTrie.traverse_from
     when possible.
     """
-    node_db, trie = trie_from_keys(trie_keys)
+    node_db, trie = trie_from_keys(trie_keys, prune=True)
 
     number_explorations %= len(node_db)
     cache = TrieFrontierCache()

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -209,6 +209,19 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, minimum_value_lengt
     index_nibbles=[],
     index_nibbles2=[],
 )
+@example(
+    # Interesting scenario:
+    #   - during trie change, delete prunes leaf node for key b'\x00\x01\x00'
+    #   - *after* pruning, a MissingTrieNode is raised during a normalize step
+    #   - this exception ought to revert the delete, but it's too late
+    #   - a subsequent attempt to delete the key fails because the leaf node is missing
+    trie_keys=[b'\x00\x01\x00', b'\x00\x01\x01', b'\x00\x00\x00'],
+    minimum_value_length=27,
+    number_explorations=0,
+    trie_changes=[(1, None), (3, None)],
+    index_nibbles=[],
+    index_nibbles2=[],
+)
 def test_trie_walk_root_change_with_traverse(
         trie_keys,
         minimum_value_length,

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -185,20 +185,6 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
         max_size=4 * 2,  # one byte (two nibbles) deeper than the longest key above
     ),
 )
-@settings(max_examples=200)
-@example(
-    trie_keys=[
-        b'\x00\x00\x00',
-        b'\x01\x00\x00',
-        b'\x01\x00\x01',
-        b'\x10\x00\x00',
-    ],
-    minimum_value_length=0,
-    number_explorations=212,
-    trie_changes=[(1, b'\x00\x00\x00\x00\x00\x00\x00'), (4, None)],
-    index_nibbles=[],
-    index_nibbles2=[],
-)
 @example(
     # Catch bug where TraversedPartialPath is raised when traversing into a leaf,
     #   even though the leaf suffix doesn't match the prefix that was being traversed to.

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -222,6 +222,16 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, minimum_value_lengt
     index_nibbles=[],
     index_nibbles2=[],
 )
+@example(
+    # Catch bug where TraversedPartialPath is raised when traversing into a leaf,
+    #   even though the leaf suffix doesn't match the prefix that was being traversed to.
+    trie_keys=[b'\x00\x00\x00', b'\x10\x00\x00'],
+    minimum_value_length=26,
+    number_explorations=86,
+    trie_changes=[(1, None)],
+    index_nibbles=[],
+    index_nibbles2=[],
+)
 def test_trie_walk_root_change_with_traverse(
         trie_keys,
         minimum_value_length,

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -194,7 +194,7 @@ class HexaryTrie:
 
         if remaining_key:
             path_to_node = trie_key[:len(trie_key) - len(remaining_key)]
-            raise TraversedPartialPath(path_to_node, annotated_node)
+            raise TraversedPartialPath(path_to_node, annotated_node, remaining_key)
         else:
             return annotated_node
 
@@ -225,7 +225,7 @@ class HexaryTrie:
 
         if remaining_key:
             path_to_node = trie_key[:len(trie_key) - len(remaining_key)]
-            raise TraversedPartialPath(path_to_node, annotated_node)
+            raise TraversedPartialPath(path_to_node, annotated_node, remaining_key)
         else:
             return annotated_node
 

--- a/trie/tools/strategies.py
+++ b/trie/tools/strategies.py
@@ -25,7 +25,7 @@ def random_trie_strategy(draw):
 
 
 @st.composite
-def trie_keys_with_extensions(draw):
+def trie_keys_with_extensions(draw, allow_empty_trie=True):
     """
     Build trie keys that tend to have lots of extension/branch/leaf nodes.
     Anecdotally, this was more likely to produce examples like the one
@@ -34,7 +34,7 @@ def trie_keys_with_extensions(draw):
     # Simplest possible trie: an empty trie
     # Test it about once, on average, per run of 200 tests (the default example count)
     # Also, this will shrink down to the empty trie as you shrink these integers.
-    if draw(st.integers(min_value=0, max_value=200)) == 0:
+    if allow_empty_trie and draw(st.integers(min_value=0, max_value=200)) == 0:
         return ()
 
     def build_up_from_children(children):


### PR DESCRIPTION
### What was wrong?

When traversing to a node, we occasionally get `TraversedPartialPath` exceptions (if the trie changed in the middle of walking it). In that case, we want some help from the exception to continue our walk. Previously, we would build the sub-segments manually, but that was error-prone, and turns out that it got broken in a refactor and we didn't notice!

### How was it fixed?

Fix the broken TPP handling in the walk tests. Add a new `simulated_node` which helps simplify the handling.

Also, add a new hypothesis strategy that is more likely to catch issues like this, by focusing on building some long extension nodes. (which is not super likely to happen in a smooth uniform random distribution of keys)

~PR is nearly ready, just waiting to merge #113 and #114 and rebase.~

TODO:
- [x] changelog
- [x] readme update
- [x] squashing
- [x] squashing (after review)

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/a8/89/64/a88964c605c007af26899a6c953f6128.jpg)