### PR TITLE
Bugfix no-op squash_changes on a pruning trie

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,10 @@ Bugfixes
   that was pruned before the exception was raised might stay pruned, even though the trie
   wasn't updated.
   https://github.com/ethereum/py-trie/pull/109
+- When using squash_changes() on a HexaryTrie with prune=True, doing a no-op change would
+  cause the root node to get pruned (deleted even though it was still needed for the current
+  root hash!).
+  https://github.com/ethereum/py-trie/pull/113
 
 
 v2.0.0-alpha.1

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -17,14 +17,14 @@ from trie.iter import NodeIterator
 from trie.typing import Nibbles
 
 
-def _make_trie(keys):
+def _make_trie(keys, prune=False):
     """
     Make a new HexaryTrie, insert all the given keys, with the value equal to the key.
     Return the raw database and the HexaryTrie.
     """
     # Create trie
     node_db = {}
-    trie = HexaryTrie(node_db)
+    trie = HexaryTrie(node_db, prune=prune)
     with trie.squash_changes() as trie_batch:
         for k in keys:
             trie_batch[k] = k

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -5,7 +5,6 @@ from hypothesis import (
     strategies as st,
 )
 
-from trie import HexaryTrie
 from trie.exceptions import (
     TraversedPartialPath,
     MissingTraversalNode,
@@ -14,22 +13,8 @@ from trie.exceptions import (
 )
 from trie.fog import HexaryTrieFog, TrieFrontierCache
 from trie.iter import NodeIterator
+from trie.tools.builder import trie_from_keys
 from trie.typing import Nibbles
-
-
-def _make_trie(keys, prune=False):
-    """
-    Make a new HexaryTrie, insert all the given keys, with the value equal to the key.
-    Return the raw database and the HexaryTrie.
-    """
-    # Create trie
-    node_db = {}
-    trie = HexaryTrie(node_db, prune=prune)
-    with trie.squash_changes() as trie_batch:
-        for k in keys:
-            trie_batch[k] = k
-
-    return node_db, trie
 
 
 @given(
@@ -52,7 +37,7 @@ def test_trie_walk_backfilling(trie_keys, index_nibbles):
     - Every time a node is missing from the DB, replace it and retry
     - Repeat until full trie has been explored with the HexaryTrieFog
     """
-    node_db, trie = _make_trie(trie_keys)
+    node_db, trie = trie_from_keys(trie_keys)
     index_key = Nibbles(index_nibbles)
 
     # delete all nodes
@@ -109,7 +94,7 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
     """
     Like test_trie_walk_backfilling but using the HexaryTrie.traverse_from API
     """
-    node_db, trie = _make_trie(trie_keys)
+    node_db, trie = trie_from_keys(trie_keys)
     index_key = Nibbles(index_nibbles)
 
     # delete all nodes
@@ -226,7 +211,7 @@ def test_trie_walk_root_change_with_traverse(
     - Verify that all required database values were replaced (where only the nodes under
         the NEW trie root are required)
     """
-    node_db, trie = _make_trie(trie_keys)
+    node_db, trie = trie_from_keys(trie_keys)
 
     number_explorations %= len(node_db)
 
@@ -378,7 +363,7 @@ def test_trie_walk_root_change_with_cached_traverse_from(
     Like test_trie_walk_root_change_with_traverse but using HexaryTrie.traverse_from
     when possible.
     """
-    node_db, trie = _make_trie(trie_keys)
+    node_db, trie = trie_from_keys(trie_keys)
 
     number_explorations %= len(node_db)
     cache = TrieFrontierCache()

--- a/trie/tools/builder.py
+++ b/trie/tools/builder.py
@@ -1,0 +1,16 @@
+from trie import HexaryTrie
+
+
+def trie_from_keys(keys, prune=False):
+    """
+    Make a new HexaryTrie, insert all the given keys, with the value equal to the key.
+    Return the raw database and the HexaryTrie.
+    """
+    # Create trie
+    node_db = {}
+    trie = HexaryTrie(node_db, prune=prune)
+    with trie.squash_changes() as trie_batch:
+        for k in keys:
+            trie_batch[k] = k
+
+    return node_db, trie


### PR DESCRIPTION
`squash_changes` was trying to prune the root node, when it was unchanged from the original trie. This only matters when the original trie has `prune=True`, which isn't a heavily-tested scenario. But we need it for some trie walk tests. The problem is that the temporary trie during squashing had an empty ref-count, so it didn't know that the old root was still needed. To solve the problem, we pass through the parent trie's ref-count.

This was caught when trying to walk over a trie that's pruning, and runs a squash-changes, but sometimes doesn't change anything at all (see #111). It's important to prune while walking because we want to run mid-walk trie updates. Those updates should delete access to old nodes, to simulate losing access to old trie nodes from peers that have moved on. This makes sure we don't request trie nodes that don't exist anymore during backfill-only type scenarios.

TODO:
- [x] CHANGELOG

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/a0/72/6a/a0726a33b04d679c9e2ff9a6d5d25972.jpg)