### PR TITLE
Fix overzealous TraversedPartialPath raised on leaves

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,9 @@ Bugfixes
   cause the root node to get pruned (deleted even though it was still needed for the current
   root hash!).
   https://github.com/ethereum/py-trie/pull/113
+- Only raise a TraversedPartialPath when traversing into a matching leaf node. Instead, return
+  an empty node when traversing into a divergent path.
+  https://github.com/ethereum/py-trie/pull/114
 
 
 v2.0.0-alpha.1

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -377,7 +377,7 @@ def trie_updates_strategy(draw, max_size=256):
         ],
     ),
 )
-@settings(max_examples=300)
+@settings(max_examples=100)
 def test_squash_changes_does_not_prune_on_missing_trie_node(inserts_and_updates):
     inserts, updates = inserts_and_updates
     node_db = {}
@@ -448,7 +448,7 @@ def test_squash_changes_does_not_prune_on_missing_trie_node(inserts_and_updates)
     updates=[(b'\x01', b'\x00'), (b'\x01\x00', b'\x00')],
     deleted=[b''],
 )
-@settings(max_examples=1000)
+@settings(max_examples=500)
 def test_hexary_trie_squash_all_changes(updates, deleted):
     db = {}
     trie = HexaryTrie(db=db)

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -150,6 +150,8 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
         min_size=1,
         max_size=1024,
     ),
+    # minimum value length (to help force trie nodes to stop embedding)
+    st.integers(min_value=0, max_value=32),
     # how many fog expansions to try before modifying the trie
     st.integers(min_value=0, max_value=10000),
     # all trie changes to make before the second trie walk
@@ -191,6 +193,7 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
         b'\x01\x00\x01',
         b'\x10\x00\x00',
     ],
+    minimum_value_length=0,
     number_explorations=212,
     trie_changes=[(1, b'\x00\x00\x00\x00\x00\x00\x00'), (4, None)],
     index_nibbles=[],
@@ -198,6 +201,7 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
 )
 def test_trie_walk_root_change_with_traverse(
         trie_keys,
+        minimum_value_length,
         number_explorations,
         trie_changes,
         index_nibbles,

--- a/tests/test_hexary_trie_walk.py
+++ b/tests/test_hexary_trie_walk.py
@@ -199,6 +199,16 @@ def test_trie_walk_backfilling_with_traverse_from(trie_keys, index_nibbles):
     index_nibbles=[],
     index_nibbles2=[],
 )
+@example(
+    # Catch bug where TraversedPartialPath is raised when traversing into a leaf,
+    #   even though the leaf suffix doesn't match the prefix that was being traversed to.
+    trie_keys=[b'\x00\x00\x00', b'\x10\x00\x00'],
+    minimum_value_length=26,
+    number_explorations=86,
+    trie_changes=[(1, None)],
+    index_nibbles=[],
+    index_nibbles2=[],
+)
 def test_trie_walk_root_change_with_traverse(
         trie_keys,
         minimum_value_length,

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -247,9 +247,15 @@ class HexaryTrie:
             node_type = get_node_type(node)
 
             if node_type == NODE_TYPE_BLANK:
-                return BLANK_NODE, Nibbles(())  # type: ignore # mypy thinks BLANK_NODE != b''
+                return BLANK_NODE, ()  # type: ignore # mypy thinks BLANK_NODE != b''
             elif node_type == NODE_TYPE_LEAF:
-                return node, remaining_key
+                leaf_key = extract_key(node)
+                if key_starts_with(leaf_key, remaining_key):
+                    return node, remaining_key
+                else:
+                    # The trie key and leaf node key branch away from each other, so there
+                    # is no node at the specified key.
+                    return BLANK_NODE, ()  # type: ignore # mypy thinks BLANK_NODE != b''
             elif node_type == NODE_TYPE_EXTENSION:
                 try:
                     next_node_pointer, remaining_key = self._traverse_extension(node, remaining_key)

--- a/trie/tools/builder.py
+++ b/trie/tools/builder.py
@@ -1,7 +1,7 @@
 from trie import HexaryTrie
 
 
-def trie_from_keys(keys, prune=False):
+def trie_from_keys(keys, minimum_value_length=0, prune=False):
     """
     Make a new HexaryTrie, insert all the given keys, with the value equal to the key.
     Return the raw database and the HexaryTrie.
@@ -11,6 +11,8 @@ def trie_from_keys(keys, prune=False):
     trie = HexaryTrie(node_db, prune=prune)
     with trie.squash_changes() as trie_batch:
         for k in keys:
-            trie_batch[k] = k
+            # Flood 3's at the end of the value to make it longer. b'3' is encoded to 0x33,
+            #   so the bytes and HexBytes representation look the same. Just a convenience.
+            trie_batch[k] = k.ljust(minimum_value_length, b'3')
 
     return node_db, trie


### PR DESCRIPTION
### What was wrong?

`.traverse()` was raising a `TraversedPartialPath` with a leaf node, even if you try to traverse on a path unrelated to the leaf. Instead, if you traverse into an unrelated path, you should just get an empty node.

### How was it fixed?

Return the empty node if the traversed path doesn't match the beginning of the leaf suffix.

TODO:
- [x] changelog
- [x] rebase on #113 after it's merged

#### Cute Animal Picture

![Cute animal picture](https://i.ytimg.com/vi/J_4aEicC28A/maxresdefault.jpg)
