### PR TITLE
Loosen typing-extensions version to semver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<2",
         "sortedcontainers>=2.1.0,<3",
-        "typing-extensions==3.7.4.2",
+        "typing-extensions>=3.7.4,<4",
     ],
     extras_require=extras_require,
     license="MIT",


### PR DESCRIPTION
### What was wrong?

typing-extensions was pinned (not sure why?) to a version. It was causing build problems for trinity:
https://app.circleci.com/pipelines/github/ethereum/trinity/7295/workflows/507aaeee-b94f-45f6-951e-7cd53e5b4536/jobs/278793

```
docker run ethereum/trinity:test-build --help
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 582, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 899, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 790, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (typing-extensions 3.7.4.3 (/usr/local/lib/python3.7/site-packages), Requirement.parse('typing-extensions==3.7.4.2'), {'trie'})
```

### How was it fixed?

Loosened up to semver.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/69/bc/67/69bc67f0af26bad3d5fdeb96d580b1a8.jpg)