### PR TITLE
Relax rlp dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "eth-hash>=0.1.0,<1.0.0",
         "eth-utils>=1.6.1,<2.0.0",
         "hexbytes>=0.2.0,<0.3.0",
-        "rlp>=1,<=2.0.0-alpha.1",
+        "rlp>=1,<3",
         "sortedcontainers>=2.1.0,<3",
         "typing-extensions>=3.7.4,<4",
     ],


### PR DESCRIPTION
### What was wrong?

The current RLP dependency has a hard bound on `2.0.0a1`. Trinity, Py-EVM and friends need to migrate to `2.0.0a2` so we need to update the dependency. 

### How was it fixed?

Changed it to `"rlp>=1,<3"`. I guess the argument against an upper bound of `<3` is that we don't know yet if we end up making actual breaking changes to rlp 2 so it would be safer to pin it to `2.0.0a2`. On the other hand, having to cut new releases in `trie`,`py-evm`, `eth-rlp`, `eth-account` and `eth-tester` just because Trinity wants to go from `2.0.0a1` to `2.0.0a2` is unfortunate, too so maybe an upper bound of `<3` isn't actually that bad.

#### Cute Animal Picture

![Cute animal picture](https://imgs.abduzeedo.com/files/articles/baby-animals/Baby-Animals-001.jpg)
