### PR TITLE
Add node_type field to HexaryTrieNode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,11 @@
 Unreleased
 ---------------
 
-None
+Features
+~~~~~~~~
+
+- Added node_type field to HexaryTrieNode so that users can easily inspect the type
+  of a node.
 
 v2.0.0-alpha.4
 ---------------

--- a/trie/exceptions.py
+++ b/trie/exceptions.py
@@ -5,7 +5,12 @@ from eth_typing import (
 )
 from hexbytes import HexBytes
 
+from trie.constants import (
+    NODE_TYPE_EXTENSION,
+    NODE_TYPE_LEAF
+)
 from trie.typing import (
+    NodeType,
     Nibbles,
     NibblesInput,
     HexaryTrieNode,
@@ -242,6 +247,7 @@ class TraversedPartialPath(Exception):
                 actual_node.value,
                 trimmed_suffix,
                 [compute_leaf_key(trimmed_suffix), actual_node.raw[1]],
+                NodeType(NODE_TYPE_LEAF),
             )
         elif len(actual_sub_segments) == 1:
             extension = actual_sub_segments[0]
@@ -261,6 +267,7 @@ class TraversedPartialPath(Exception):
                 actual_node.value,
                 actual_node.suffix,
                 [compute_extension_key(trimmed_extension), actual_node.raw[1]],
+                NodeType(NODE_TYPE_EXTENSION),
             )
         else:
             raise ValidationError(

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -17,6 +17,12 @@ from eth_utils import (
     is_list_like,
 )
 
+from trie.constants import (
+    NODE_TYPE_BLANK,
+    NODE_TYPE_BRANCH,
+    NODE_TYPE_EXTENSION,
+    NODE_TYPE_LEAF,
+)
 
 # The RLP-decoded node is either blank, or a list, full of bytes or recursive nodes
 # Recursive definitions don't seem supported at the moment, follow:
@@ -87,6 +93,13 @@ class Nibbles(Tuple[Nibble, ...]):
             p.text(super().__repr__())
 
 
+class NodeType(enum.IntEnum):
+    BLANK = NODE_TYPE_BLANK
+    LEAF = NODE_TYPE_LEAF
+    EXTENSION = NODE_TYPE_EXTENSION
+    BRANCH = NODE_TYPE_BRANCH
+
+
 class HexaryTrieNode(NamedTuple):
     """
     Public API for a node of a trie, it is pre-processed a bit for simplicity.
@@ -120,6 +133,12 @@ class HexaryTrieNode(NamedTuple):
     """
     The node body, which is useful for calls to HexaryTrie.traverse_from(...),
     for faster access of sub-nodes.
+    """
+
+    node_type: NodeType
+    """
+    The node type (leaf, branch, extension, blank). Useful for understanding the
+    structure of the trie, but should not be checked often in normal usage.
     """
 
 

--- a/trie/utils/nodes.py
+++ b/trie/utils/nodes.py
@@ -24,6 +24,7 @@ from trie.utils.binaries import (
 from trie.typing import (
     HexaryTrieNode,
     Nibbles,
+    NodeType,
     RawHexaryNode,
 )
 from trie.validation import (
@@ -194,6 +195,7 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
             value=bytes(node_body[-1]),
             suffix=Nibbles(extract_key(node_body)),
             raw=node_body,
+            node_type=NodeType(node_type),
         )
     elif node_type == NODE_TYPE_BRANCH:
         sub_segments = tuple(
@@ -205,6 +207,7 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
             value=bytes(node_body[-1]),
             suffix=Nibbles(()),
             raw=node_body,
+            node_type=NodeType(node_type),
         )
     elif node_type == NODE_TYPE_EXTENSION:
         key_extension = extract_key(node_body)
@@ -213,6 +216,7 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
             value=b'',
             suffix=Nibbles(()),
             raw=node_body,
+            node_type=NodeType(node_type),
         )
     elif node_type == NODE_TYPE_BLANK:
         # empty trie
@@ -221,6 +225,7 @@ def annotate_node(node_body: RawHexaryNode) -> HexaryTrieNode:
             value=b'',
             suffix=Nibbles(()),
             raw=node_body,
+            node_type=NodeType(node_type),
         )
     else:
         raise NotImplementedError()


### PR DESCRIPTION
### What was wrong?

It looks like `get_node_type` only accepts a `RawHexaryNode`, but I think it makes sense for it to also accept a `HexaryTrieNode` instead of throwing an exception:

```python
>>> t = HexaryTrie(db={})
>>> t.set(b'test', b'test_value')
>>> get_node_type(t.root_node)
```
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ftruzzi/projects/ethereum/py-trie/trie/utils/nodes.py", line 55, in get_node_type
    return NODE_TYPE_EXTENSION
trie.exceptions.InvalidNode: Unable to determine node type
```

### How was it fixed?

~~Made `get_node_type` access the raw node if a `HexaryTrieNode` is passed as an argument.~~

Added node_type field to `HexaryTrieNode`.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/461133/116456921-17d51000-a863-11eb-8716-c043b3326e7e.png)
