### PR TITLE
chore: upgrade typing-extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<3",
         "sortedcontainers>=2.1.0,<3",
-        "typing-extensions>=4.0.0,<5.0.0",
+        "typing-extensions>=4.0.0,<5",
     ],
     extras_require=extras_require,
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<3",
         "sortedcontainers>=2.1.0,<3",
-        "typing-extensions>=3.7.4,<4",
+        "typing-extensions<4.0.0,<5.0.0",
     ],
     extras_require=extras_require,
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<3",
         "sortedcontainers>=2.1.0,<3",
-        "typing-extensions.>=4.0.0,<5.0.0",
+        "typing-extensions>=4.0.0,<5.0.0",
     ],
     extras_require=extras_require,
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<3",
         "sortedcontainers>=2.1.0,<3",
-        "typing-extensions<4.0.0,<5.0.0",
+        "typing-extensions.>=4.0.0,<5.0.0",
     ],
     extras_require=extras_require,
     license="MIT",


### PR DESCRIPTION
### What was wrong?

We are experiencing weird build failures down the pipeline from this, related to typing extensions 4.0.0 that was just released a couple days ago.

### How was it fixed?

upgrading typing-extensions

#### Cute Animal Picture

![toy_elephant](https://user-images.githubusercontent.com/19540978/142560034-af5be34e-6a96-47cf-9ce8-37a5ba25edd2.jpeg)
