### PR TITLE
deps: upgrade typing-extensions to v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<3",
         "sortedcontainers>=2.1.0,<3",
-        "typing-extensions>=3.7.4,<4",
+        "typing-extensions>=4.0,<5.0",
     ],
     extras_require=extras_require,
     license="MIT",


### PR DESCRIPTION
### What was wrong?
`typing-extensions` v4 was released on November 15th, however the version pinning precludes it's use and causes several package conflicts due to too-tight pinning

### How was it fixed?
Upgrading the package

#### Cute Animal Picture
![angry panda](https://farm5.staticflickr.com/4055/4539048177_f0c4c064ac_z.jpg)