### PR TITLE
Support py39 py310, drop python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,12 +50,6 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: lint
-  py36:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36
   py37:
     <<: *common
     docker:
@@ -86,7 +80,6 @@ workflows:
   test:
     jobs:
       - lint
-      - py36
       - py37
       - py38
       - py39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,18 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38
+  py39:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39
+  py310:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310
 
 workflows:
   version: 2
@@ -77,3 +89,5 @@ workflows:
       - py36
       - py37
       - py38
+      - py39
+      - py310

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,24 @@
 Unreleased
 ---------------
 
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- Drop python 3.6 support
+- Require rlp dependency to be >=3,<4
+- Require eth-utils dependency to be >=2,<3
+
 Features
 ~~~~~~~~
 
 - Added node_type field to HexaryTrieNode so that users can easily inspect the type
   of a node.
+- Add support for python 3.9 and 3.10
+
+Misc
+~~~~
+
+- Upgrade typing_extensions dependency
 
 v2.0.0-alpha.4
 ---------------

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         'Natural Language :: English',
         "Operating System :: OS Independent",
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "eth-hash>=0.1.0,<1.0.0",
         "eth-utils>=2.0.0,<3.0.0",
         "hexbytes>=0.2.0,<0.3.0",
-        "rlp>=1,<3",
+        "rlp>=3,<4",
         "sortedcontainers>=2.1.0,<3",
         "typing-extensions>=4.0.0,<5",
     ],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
 
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
-        "eth-utils>=1.6.1,<2.0.0",
+        "eth-utils>=2.0.0,<3.0.0",
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=1,<3",
         "sortedcontainers>=2.1.0,<3",
@@ -68,6 +68,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development',
         'Topic :: Utilities',
     ],

--- a/tests/test_bin_trie.py
+++ b/tests/test_bin_trie.py
@@ -19,7 +19,7 @@ from trie.exceptions import (
 
 @given(k=st.lists(st.binary(min_size=32, max_size=32), min_size=100, max_size=100, unique=True),
        v=st.lists(st.binary(min_size=1), min_size=100, max_size=100),
-       random=st.randoms())
+       random=st.randoms(use_true_random=True))
 @settings(max_examples=10, deadline=1000)
 def test_bin_trie_different_order_insert(k, v, random):
     kv_pairs = list(zip(k, v))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{36,37,38}
+  py{36,37,38,39,310}
   lint
 
 [flake8]
@@ -15,6 +15,8 @@ basepython =
   py36: python3.6
   py37: python3.7
   py38: python3.8
+  py39: python3.9
+  py310: python3.10
 extras = test
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{36,37,38,39,310}
+  py{37,38,39,310}
   lint
 
 [flake8]
@@ -12,7 +12,6 @@ usedevelop=True
 commands=
   py.test {posargs:tests}
 basepython =
-  py36: python3.6
   py37: python3.7
   py38: python3.8
   py39: python3.9


### PR DESCRIPTION
### What was wrong?

We weren't officially supporting python 3.9 or 3.10.

This update requires an `eth-utils` and `pyrlp` version requirement bump. The `eth-utils` version requirement has already been updated in `setup.py`. For `pyrlp` the needed changes are in master, so once that gets released, I'll update the version requirement here and tests will pass. 

### How was it fixed?

Added CI test runs specifically for python 3.9 and 3.10. Also cleans up some deprecation warnings. 


#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/564x/f9/3d/af/f93daf43f9fc5e5c477ac3353946016e.jpg)
