### PR TITLE
Make typing-extensions optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,43 +44,64 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: lint
-  py37:
+  py37-lint:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37
-  py38:
+          TOXENV: lint
+  py38-lint:
     <<: *common
     docker:
       - image: circleci/python:3.8
         environment:
-          TOXENV: py38
-  py39:
+          TOXENV: lint
+  py39-lint:
     <<: *common
     docker:
       - image: circleci/python:3.9
         environment:
-          TOXENV: py39
-  py310:
+          TOXENV: lint
+  py310-lint:
     <<: *common
     docker:
       - image: circleci/python:3.10
         environment:
-          TOXENV: py310
+          TOXENV: lint
+  py37-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
 
 workflows:
   version: 2
   test:
     jobs:
-      - lint
-      - py37
-      - py38
-      - py39
-      - py310
+      - py37-lint
+      - py38-lint
+      - py39-lint
+      - py310-lint
+      - py37-core
+      - py38-core
+      - py39-core
+      - py310-core

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "hexbytes>=0.2.0,<0.3.0",
         "rlp>=3,<4",
         "sortedcontainers>=2.1.0,<3",
-        "typing-extensions>=4.0.0,<5",
+        "typing-extensions>=4.0.0,<5; python_version < '3.8'",
     ],
     extras_require=extras_require,
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-  py{37,38,39,310}
-  lint
+  py{37,38,39,310}-core
+  py{37,38,39,310}-lint
 
 [flake8]
 max-line-length = 100

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -24,6 +24,18 @@ from trie.constants import (
     NODE_TYPE_LEAF,
 )
 
+try:
+    from typing import (
+        Literal,
+        Protocol,
+    )
+except ImportError:
+    from typing_extensions import (
+        Literal,
+        Protocol,
+    )
+
+
 # The RLP-decoded node is either blank, or a list, full of bytes or recursive nodes
 # Recursive definitions don't seem supported at the moment, follow:
 #   https://github.com/python/mypy/issues/731

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -8,7 +8,7 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import (
+from trie.utils.compat import (
     Literal,
     Protocol,
 )
@@ -23,17 +23,6 @@ from trie.constants import (
     NODE_TYPE_EXTENSION,
     NODE_TYPE_LEAF,
 )
-
-try:
-    from typing import (
-        Literal,
-        Protocol,
-    )
-except ImportError:
-    from typing_extensions import (
-        Literal,
-        Protocol,
-    )
 
 
 # The RLP-decoded node is either blank, or a list, full of bytes or recursive nodes

--- a/trie/utils/compat/__init__.py
+++ b/trie/utils/compat/__init__.py
@@ -1,0 +1,7 @@
+import sys
+
+# remove once trie supports python>=3.8
+if sys.version_info >= (3, 8):
+    from typing import Literal, Protocol
+else:
+    from typing_extensions import Literal, Protocol  # noqa: F401


### PR DESCRIPTION
- It's not required for Python >= 3.8
