### PR TITLE
fix: reversed root->leaf to leaf->root

### DIFF
--- a/trie/smt.py
+++ b/trie/smt.py
@@ -336,8 +336,7 @@ class SparseMerkleTree:
         validate_length(key, self._key_size)
 
         try:
-            self.get(key)
-            return True
+            return self.get(key) == self._default
         except KeyError:
             return False
 


### PR DESCRIPTION
### What was wrong?
reversed root->leaf to leaf->root in trie/smt.py


### How was it fixed?
removed reversed()


#### Cute Animal Picture
https://i.natgeofe.com/k/c022030e-f1aa-4ab3-ad56-fdcdd4a1d08b/125-animals-tiger_4x3.jpg


fixes #129