### PR TITLE
Remove hexbytes upper version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
         "eth-utils>=2.0.0,<3.0.0",
-        "hexbytes>=0.2.0,<0.3.0",
+        "hexbytes>=0.2.0",
         "rlp>=3,<4",
         "sortedcontainers>=2.1.0,<3",
         "typing-extensions>=4.0.0,<5; python_version < '3.8'",


### PR DESCRIPTION
### What was wrong?
Dependency hell. This library couldn't be updated because of the hexbytes dependency upper pin.


### How was it fixed?

We've been considering removing the upper dependency pin specifications throughout our stack, so thought I would try it out here. 


#### Cute Animal Picture

![Cute animal picture](https://static.boredpanda.com/blog/wp-content/uploads/2019/07/cute-harvest-mouses-dean-mason-photography-2-5d244752a8e91__700.jpg)
