### PR TITLE
Upgrade flake8 & hypothesis, to fix master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
         "pycryptodome",
     ],
     'lint': [
-        "flake8==3.8.1",
+        "flake8==5.0.4",
     ],
     'dev': [
         "bumpversion>=0.5.3,<1",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
     'test': [
         "pytest-xdist>=1.31.0,<2",
         "tox>=2.6.0,<3",
-        "hypothesis>=5.10.4,<6",
+        "hypothesis>=6.56.4,<7",
         "pycryptodome",
     ],
     'lint': [


### PR DESCRIPTION
`flake8` had too loose of a constraint and one of their dependencies (importlib-metadata) dropped an API that they require.

See:
https://github.com/ethereum/ethereum-python-project-template/pull/69#issuecomment-1312175790

### What was wrong?

```
lint create: /home/circleci/repo/.tox/lint
lint develop-inst: /home/circleci/repo
lint installed: cytoolz==0.12.0,eth-hash==0.3.3,eth-typing==3.2.0,eth-utils==2.0.0,flake8==3.8.1,hexbytes==0.3.0,importlib-metadata==5.0.0,mccabe==0.6.1,pycodestyle==2.6.0,pyflakes==2.2.0,rlp==3.0.0,sortedcontainers==2.4.0,toolz==0.12.0,-e git+ssh://git@github.com/ethereum/py-trie.git@36f184c91ec07d088210d720488909df780d4ba3#egg=trie,typing_extensions==4.4.0,zipp==3.10.0
lint run-test-pre: PYTHONHASHSEED='579183366'
lint run-test: commands[0] | flake8 /home/circleci/repo/trie /home/circleci/repo/tests
Traceback (most recent call last):
  File "/home/circleci/repo/.tox/lint/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/home/circleci/repo/.tox/lint/lib/python3.7/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/home/circleci/repo/.tox/lint/lib/python3.7/site-packages/flake8/main/application.py", line 360, in run
    self._run(argv)
  File "/home/circleci/repo/.tox/lint/lib/python3.7/site-packages/flake8/main/application.py", line 347, in _run
    self.initialize(argv)
  File "/home/circleci/repo/.tox/lint/lib/python3.7/site-packages/flake8/main/application.py", line 328, in initialize
    self.find_plugins(config_finder)
  File "/home/circleci/repo/.tox/lint/lib/python3.7/site-packages/flake8/main/application.py", line 153, in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
  File "/home/circleci/repo/.tox/lint/lib/python3.7/site-packages/flake8/plugins/manager.py", line 357, in __init__
    self.namespace, local_plugins=local_plugins
  File "/home/circleci/repo/.tox/lint/lib/python3.7/site-packages/flake8/plugins/manager.py", line 238, in __init__
    self._load_entrypoint_plugins()
  File "/home/circleci/repo/.tox/lint/lib/python3.7/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
AttributeError: 'EntryPoints' object has no attribute 'get'
ERROR: InvocationError for command /home/circleci/repo/.tox/lint/bin/flake8 trie tests (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   lint: commands failed


Exited with code exit status 1
```

v5 of importlib-metadata dropped a deprecated API.

### How was it fixed?

This issue was fixed in a more recent flake8 release, so upgraded to a more recent flake8. ~~This will probably require some lint changes...~~ _Interestingly, not!_

Hypothesis had the same issue. Updated that, and the problem went away.

#### Cute Animal Picture

![Cute animal picture](https://animals.sandiegozoo.org/sites/default/files/2019-06/animals-pygmy-slow-loris.jpg)
