### PR TITLE
Remove reference to RTD

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,7 @@ Summary of approach.
 [//]: # (Stay ahead of things, add list items here!)
 - [ ] Clean up commit history
 
-[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
-- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)
+- [ ] Add description of changes to CHANGELOG
 
 #### Cute Animal Picture
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist=
 [isort]
 combine_as_imports=True
 force_sort_within_sections=True
+force_grid_wrap=1
 known_third_party=hypothesis,pytest
 profile=black
 multi_line_output=3
@@ -35,5 +36,5 @@ extras=lint
 whitelist_externals=black
 commands=
     flake8 {toxinidir}/trie {toxinidir}/tests
-    isort --check-only --diff --multi-line=VERTICAL_HANGING_INDENT --fgw=1 --ca {toxinidir}/trie {toxinidir}/tests
+    isort --check-only --diff {toxinidir}/trie {toxinidir}/tests
     black --check {toxinidir}/trie {toxinidir}/tests {toxinidir}/setup.py


### PR DESCRIPTION
## What was wrong?
There was a stray Read the Docs reference in the Pull Request Template. 

## How was it fixed?

Removed it. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
