### PR TITLE
convert .format to f-strings, other cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ common: &common
         command: ./.circleci/merge_pr.sh
         when: on_fail
     - run:
-        name: merge pull request base (3nd try)
+        name: merge pull request base (3rd try)
         command: ./.circleci/merge_pr.sh
         when: on_fail
     - restore_cache:

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,8 @@ CURRENT_SIGN_SETTING := $(shell git config commit.gpgSign)
 help:
 	@echo "clean-build - remove build artifacts"
 	@echo "clean-pyc - remove Python file artifacts"
-	@echo "dist - package"
 	@echo "lint - check style with black, flake8, and isort"
 	@echo "lint-roll - automatically fix problems with isort and black"
-	@echo "release - package and upload a release (does not run notes target)"
 	@echo "test - run tests quickly with the default Python"
 	@echo "docs - view draft of newsfragments to be added to CHANGELOG"
 	@echo "notes - consume towncrier newsfragments/ and update CHANGELOG"

--- a/newsfragments/138.internal.rst
+++ b/newsfragments/138.internal.rst
@@ -1,0 +1,1 @@
+convert old-style `format` strings to f-strings, additional cleanup

--- a/tests/test_bin_trie.py
+++ b/tests/test_bin_trie.py
@@ -76,7 +76,7 @@ def test_bin_trie_different_order_insert(k, v, random):
             b"\x12\x34\x56\x78\x9a",
             False,
             True,
-        ),  # noqa: E501
+        ),
     ),
 )
 def test_bin_trie_delete_subtrie(

--- a/tests/test_hexary_trie.py
+++ b/tests/test_hexary_trie.py
@@ -95,7 +95,7 @@ RAW_FIXTURES = tuple(
 
 FIXTURES_NORMALIZED = tuple(
     (
-        "{0}:{1}".format(fixture_filename, key),
+        f"{fixture_filename}:{key}",
         normalize_fixture(fixtures[key]),
     )
     for fixture_filename, fixtures in RAW_FIXTURES

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -38,7 +38,7 @@ RAW_NEXT_PREV_FIXTURES = [
     (os.path.basename(NEXT_PREV_FIXTURE_PATH), json.load(open(NEXT_PREV_FIXTURE_PATH)))
 ]
 NEXT_PREV_FIXTURES = [
-    ("{0}:{1}".format(fixture_filename, key), fixtures[key])
+    (f"{fixture_filename}:{key}", fixtures[key])
     for fixture_filename, fixtures in RAW_NEXT_PREV_FIXTURES
     for key in sorted(fixtures.keys())
 ]

--- a/trie/hexary.py
+++ b/trie/hexary.py
@@ -423,7 +423,7 @@ class HexaryTrie:
                 return proven_snapshot.get(key)
             except MissingTrieNode as e:
                 raise BadTrieProof(
-                    "Missing proof node with hash {}".format(e.missing_node_hash)
+                    f"Missing proof node with hash {e.missing_node_hash}"
                 )
 
     def get_proof(self, key):

--- a/trie/validation.py
+++ b/trie/validation.py
@@ -10,16 +10,12 @@ from trie.exceptions import (
 
 def validate_is_bytes(value):
     if not isinstance(value, bytes):
-        raise ValidationError(
-            "Value is not of type `bytes`: got '{0}'".format(type(value))
-        )
+        raise ValidationError(f"Value is not of type `bytes`: got '{type(value)}'")
 
 
 def validate_length(value, length):
     if len(value) != length:
-        raise ValidationError(
-            "Value is of length {0}.  Must be {1}".format(len(value), length)
-        )
+        raise ValidationError(f"Value is of length {len(value)}.  Must be {length}")
 
 
 def validate_is_node(node):
@@ -43,11 +39,11 @@ def validate_is_node(node):
                 validate_is_bytes(sub_node)
                 validate_length(sub_node, 32)
     else:
-        raise ValidationError("Invalid Node: {0}".format(node))
+        raise ValidationError(f"Invalid Node: {node}")
 
 
 def validate_is_bin_node(node):
     if node == BLANK_HASH or node[0] in BINARY_TRIE_NODE_TYPES:
         return
     else:
-        raise ValidationError("Invalid Node: {0}".format(node))
+        raise ValidationError(f"Invalid Node: {node}")


### PR DESCRIPTION
### What was wrong?

Old-style `.format` strings were still being used.

### How was it fixed?

Converted to f-strings, plus other typo fixes and cleanup

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-trie/assets/5199899/d1fe5e7d-c6b5-43d4-a840-c346430ec2ad)