### PR TITLE
fixes: from from in the example given

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ b'V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n[H\xe0\x1b\x99l\xad\xc0\x0
 b'\xf8\xdd\xe4\x0f\xaa\xf4P7\xfa$\xfde>\xec\xb4i\x00N\xa3)\xcf\xef\x80\xc4YU\xe8\xe7\xbf\xa89\xd5'
 
 # Initialize a fog object to track unexplored prefixes in a trie walk
->>> from from trie.fog import HexaryTrieFog
+>>> from trie.fog import HexaryTrieFog
 >>> empty_fog = HexaryTrieFog()
 # At the beginning, the unexplored prefix is (), which means that none of the trie has been explored
 >>> prefix = empty_fog.nearest_unknown()

--- a/newsfragments/139.docs.rst
+++ b/newsfragments/139.docs.rst
@@ -1,0 +1,1 @@
+Remove typo in README


### PR DESCRIPTION
### What was wrong?
In the example `Walking a full trie` in the README file, `from was used twice before trie.fog import HexaryTrieFog`

Related to Issue # None
Closes # Fixes a typo in the README file, thus, ensuring that future learners don't encounter the below error:

```python
>>> from from trie.fog import HexaryTrieFog
  File "<stdin>", line 1
    from from trie.fog import HexaryTrieFog
         ^^^^
SyntaxError: invalid syntax
```

### How was it fixed?
Removed the extra from

### Todo:
- [ Adds one commit ] Clean up commit history

- [ Not required ] Add or update documentation related to these changes

- [ Not needed] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![Cute Animal](https://github.com/ethereum/py-trie/assets/32358081/2529dde9-d240-41c8-9cdf-894cf9a39c64)