### PR TITLE
add upper pin to hexbytes dep due to incoming breaking update in 0.4.0

### DIFF
--- a/newsfragments/141.internal.rst
+++ b/newsfragments/141.internal.rst
@@ -1,0 +1,1 @@
+Add upper pin to ``hexbytes`` dependency to due incoming breaking change

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         "eth-hash>=0.1.0",
         "eth-utils>=2.0.0",
-        "hexbytes>=0.2.0",
+        "hexbytes>=0.2.0,<0.4.0",
         "rlp>=3",
         "sortedcontainers>=2.1.0",
         "typing-extensions>=4.0.0,<5; python_version < '3.8'",


### PR DESCRIPTION
### What was wrong?

The hexbytes lib will be changing the way Hexbytes.hex() works - https://github.com/ethereum/hexbytes/issues/14

### How was it fixed?

Add upper pin to hexbytes dep now, then the next release will use hexbytes 0.4.0 as a lower bound.

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-trie/assets/5199899/29af3066-ed35-402d-ab95-6d31eb6a7bd1)