### PR TITLE
Fix failing tests after updating fixtures

### DIFF
--- a/newsfragments/143.internal.rst
+++ b/newsfragments/143.internal.rst
@@ -1,0 +1,1 @@
+Update `ethereum/tests` fixture to ``v12.4``.


### PR DESCRIPTION
### What was wrong?

closes #126
closes #131 

- Update fixture to ``v12.4`` (commit hash [6613563](https://github.com/ethereum/tests/releases/tag/v12.4))
- It looks as though the fixtures submodule hadn't been updated in a long time. There were failing tests but they did not reflect issues with the library, only issues in the test setup. The order of the updates was not being preserved for some tests where this is crucial. These changes only perform permutations on tests where there aren't updates to the same key value and the key still exists in the final state (is not deleted). For those tests, we have to preserve the update order.

### Todo:
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://camo.githubusercontent.com/0a610358df78ffe3f427354a683e6c4d8596874718caefe0fa79f8dfeb939893/68747470733a2f2f65787465726e616c2d636f6e74656e742e6475636b6475636b676f2e636f6d2f69752f3f753d687474707325334125324625324677616c6c7061706572636176652e636f6d25324677702532467770323337303633352e6a706726663d31266e6f66623d31)