### PR TITLE
remove typing compat for types introduced in py38

### DIFF
--- a/newsfragments/146.internal.rst
+++ b/newsfragments/146.internal.rst
@@ -1,0 +1,1 @@
+Import types ``Literal`` and ``Protocol`` directly from ``typing`` since now >py38

--- a/trie/typing.py
+++ b/trie/typing.py
@@ -2,7 +2,9 @@ import enum
 from typing import (
     Iterable,
     List,
+    Literal,
     NamedTuple,
+    Protocol,
     Sequence,
     Tuple,
     TypeVar,
@@ -18,10 +20,6 @@ from trie.constants import (
     NODE_TYPE_BRANCH,
     NODE_TYPE_EXTENSION,
     NODE_TYPE_LEAF,
-)
-from trie.utils.compat import (
-    Literal,
-    Protocol,
 )
 
 # The RLP-decoded node is either blank, or a list, full of bytes or recursive nodes

--- a/trie/utils/compat/__init__.py
+++ b/trie/utils/compat/__init__.py
@@ -1,6 +1,0 @@
-import sys
-
-from typing_extensions import (
-    Literal,
-    Protocol,
-)


### PR DESCRIPTION
### What was wrong?

py37 trie used types that were introduced in py38 by importing them from typing_extensions

### How was it fixed?

Since now >py38, imported them directly from `typing` and delete the `compat` code.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-trie/assets/5199899/28cfac18-d8cb-4fc0-a9bd-dfdd4dc211a9)
