### PR TITLE
change master branch refs to main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Closes #
 
 - [ ] Add or update documentation related to these changes
 
-- [ ] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/master/newsfragments/README.md)
+- [ ] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/main/newsfragments/README.md)
 
 #### Cute Animal Picture
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The version format for this repo is `{major}.{minor}.{patch}` for stable, and
 
 To issue the next version in line, specify which part to bump,
 like `make release bump=minor` or `make release bump=devnum`. This is typically done from the
-master branch, except when releasing a beta (in which case the beta is released from master,
+main branch, except when releasing a beta (in which case the beta is released from main,
 and the previous stable branch is released from said branch).
 
 If you are in a beta version, `bumpversion stage` will switch to a stable.

--- a/newsfragments/147.internal.rst
+++ b/newsfragments/147.internal.rst
@@ -1,0 +1,1 @@
+Change the name of ``master`` branch to ``main``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
 log_date_format = "%m-%d %H:%M:%S"
 
 [tool.towncrier]
-# Read https://github.com/ethereum/py-trie/blob/master/newsfragments/README.md for instructions
+# Read https://github.com/ethereum/py-trie/blob/main/newsfragments/README.md for instructions
 package = "trie"
 filename = "CHANGELOG.rst"
 directory = "newsfragments"


### PR DESCRIPTION
Change the name of `master` branch to `main`

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-trie/assets/5199899/7f141600-c465-4825-bcb4-f20bf92027d1)
