### PR TITLE
bump to hexbytes>=1.2.0

### DIFF
--- a/newsfragments/151.internal.rst
+++ b/newsfragments/151.internal.rst
@@ -1,0 +1,1 @@
+Open ``hexbytes`` dep to ``>=0.2.3``

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "eth-hash>=0.1.0",
         "eth-utils>=2.0.0",
-        "hexbytes>=0.2.0,<0.4.0",
+        "hexbytes>=0.2.3",
         "rlp>=3",
         "sortedcontainers>=2.1.0",
     ],


### PR DESCRIPTION
### What was wrong?

The previous capping of `hexbytes` dep was unneeded as it wasn't actually breaking for this lib.

### How was it fixed?
Opened to `hexbytes>=0.2.3` - the first version that tested against `>=py38`

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-trie/assets/5199899/fcbb3244-4896-4386-8598-6a5a816fade4)
