### PR TITLE
fix docs ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,14 +89,32 @@ windows-wheel-steps:
       key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 docs: &docs
-  docker:
-    - image: common
+  working_directory: ~/repo
   steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: install latexpdf dependencies
         command: |
           sudo apt-get update
           sudo apt-get install latexmk tex-gyre texlive-fonts-extra
+    - run:
+        name: run tox
+        command: python -m tox run -r
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+  resource_class: xlarge
 
 jobs:
   docs:

--- a/newsfragments/155.misc.rst
+++ b/newsfragments/155.misc.rst
@@ -1,0 +1,1 @@
+Fix docs CI


### PR DESCRIPTION
### What was wrong?

Docs CI wasn't running correctly.  Now fixed.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-trie/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-trie/assets/5199899/e27c1ce4-e742-42ed-a507-0251822d6243)
